### PR TITLE
feat: add headless Docker Compose support for server deployments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+# Copy to .env and fill in values before running docker compose.
+
+# Joplin Data API token.
+# When using joplin-terminal-data-api (port 41185), auth is injected automatically
+# by the proxy — you do NOT need a real token. Leave blank or unset; the compose
+# file defaults to the placeholder "auto_injected" which satisfies startup validation.
+# Only required if connecting directly to Joplin Desktop (port 41184).
+# JOPLIN_TOKEN=
+
+# Host running joplin-data-api (default: Docker bridge gateway for Linux).
+# macOS / Windows Docker Desktop: set to host.docker.internal
+# JOPLIN_HOST=172.17.0.1
+
+# Port exposed by joplin-data-api (default: 41185).
+# Use 41184 if connecting to Joplin Desktop on the host instead.
+# JOPLIN_PORT=41185
+
+# Host port for the MCP server (change if 8000 is already in use).
+# MCP_PORT=8000
+
+# Log level: debug | info | warning | error
+# MCP_LOG_LEVEL=info

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .*
 !.dockerignore
 !.claude-plugin/
+!.env.example
+
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -471,6 +471,32 @@ docker run --rm \
 
 The container listens on `0.0.0.0:8000` by default. If exposing publicly, place behind a reverse proxy and terminate TLS there. For SSE, ensure proxy keep-alives and buffering are configured appropriately.
 
+### Headless deployment with Docker Compose
+
+For server or NAS environments where Joplin runs headlessly via
+[joplin-terminal-data-api](https://github.com/RickoNoNo3/joplin-terminal-data-api)
+rather than the desktop app, a `docker-compose.yml` is provided.
+
+**Step 1 — configure**:
+```bash
+cp .env.example .env
+# No token needed — joplin-terminal-data-api injects auth automatically.
+# Edit .env only if you need to override JOPLIN_HOST, JOPLIN_PORT, or MCP_PORT.
+```
+
+**Step 2 — start**:
+```bash
+docker compose up -d
+```
+
+`joplin-terminal-data-api` handles Joplin authentication transparently on port
+41185, so no API token is required from the client side. The MCP server connects
+to it via the Docker host bridge (`172.17.0.1` on Linux; set
+`JOPLIN_HOST=host.docker.internal` on macOS/Windows). Change `MCP_PORT` in
+`.env` if port 8000 is already in use.
+
+AI clients then connect to `http://localhost:${MCP_PORT}/mcp`.
+
 
 ## Project Structure
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,23 +1,37 @@
-# Example docker-compose configuration for local testing
-# Usage: docker compose up
+# Docker Compose for joplin-mcp — headless / server deployment
 #
-# Make sure JOPLIN_TOKEN is set in your environment or in a .env file
+# Use this when Joplin runs headlessly via joplin-terminal-data-api
+# (https://github.com/RickoNoNo3/joplin-terminal-data-api) rather than
+# the desktop app. The MCP server connects to the Data API over the
+# Docker host bridge instead of localhost.
+#
+# Usage:
+#   cp .env.example .env   # then fill in JOPLIN_TOKEN
+#   docker compose up -d
+#
+# AI clients connect to http://localhost:${MCP_PORT:-8000}/mcp
 
 services:
   joplin-mcp:
     build: .
+    restart: unless-stopped
     ports:
-      - "8000:8000"
+      - "${MCP_PORT:-8000}:8000"
     environment:
-      - JOPLIN_TOKEN=${JOPLIN_TOKEN}
-      # For macOS/Windows Docker Desktop, use host.docker.internal
-      # For Linux, use 172.17.0.1 or configure network_mode: host
-      - JOPLIN_HOST=${JOPLIN_HOST:-host.docker.internal}
-      - JOPLIN_PORT=${JOPLIN_PORT:-41184}
+      # joplin-terminal-data-api injects the real auth token automatically.
+      # A non-empty placeholder is required here only to satisfy joplin-mcp's
+      # startup validation; it is not used for actual Joplin authentication.
+      - JOPLIN_TOKEN=${JOPLIN_TOKEN:-auto_injected}
+      # Linux: use the Docker bridge gateway to reach host-exposed ports.
+      # macOS / Windows Docker Desktop: use host.docker.internal instead.
+      - JOPLIN_HOST=${JOPLIN_HOST:-172.17.0.1}
+      # Default matches joplin-terminal-data-api's exposed port (41185).
+      # Change to 41184 if connecting to a Joplin Desktop instance on the host.
+      - JOPLIN_PORT=${JOPLIN_PORT:-41185}
       - MCP_TRANSPORT=http
       - MCP_HOST=0.0.0.0
       - MCP_PORT=8000
       - MCP_LOG_LEVEL=${MCP_LOG_LEVEL:-info}
-    # Uncomment to mount config directory for persistent settings
+    # Uncomment to mount a config file for fine-grained tool control:
     # volumes:
-    #   - ./config:/config:ro
+    #   - ./joplin-mcp.json:/config/joplin-mcp.json:ro


### PR DESCRIPTION
For users running Joplin headlessly via joplin-terminal-data-api (https://github.com/RickoNoNo3/joplin-terminal-data-api) rather than the desktop app.

- docker-compose.yml: joplin-mcp service connecting to an existing joplin-data-api via Docker host bridge (172.17.0.1:41185 on Linux; host.docker.internal on macOS/Windows). No token needed — port 41185 injects auth automatically; a placeholder satisfies startup validation. All of JOPLIN_HOST, JOPLIN_PORT, and MCP_PORT are env-configurable.
- .env.example: template clarifying token is not required for headless deployments; optional overrides for host, port, and log level.
- README.md: "Headless deployment with Docker Compose" subsection added under the existing Docker section with two-step setup instructions.

Closes #14