### PR TITLE
feat(JAS-85): add get_folder_id MCP tool

### DIFF
--- a/src/joplin_mcp/tools/notebooks.py
+++ b/src/joplin_mcp/tools/notebooks.py
@@ -7,12 +7,15 @@ from joplin_mcp.fastmcp_server import (
     ItemType,
     JoplinIdType,
     RequiredStringType,
+    _compute_notebook_path,
     create_tool,
     format_creation_success,
     format_delete_success,
     format_item_list,
     format_update_success,
     get_joplin_client,
+    get_notebook_id_by_name,
+    get_notebook_map_cached,
     invalidate_notebook_map_cache,
 )
 
@@ -103,3 +106,48 @@ async def delete_notebook(
     # Invalidate cache since structure changed
     invalidate_notebook_map_cache()
     return format_delete_success(ItemType.notebook, notebook_id)
+
+
+@create_tool("get_folder_id", "Get folder ID")
+async def get_folder_id(
+    name: Annotated[
+        RequiredStringType,
+        Field(
+            description=(
+                "Notebook name or hierarchical path to look up. "
+                "Use a plain name for an exact title match (e.g. 'Work'), "
+                "or a '/'-separated path for nested notebooks "
+                "(e.g. 'Professional & Knowledge/Claude Code')."
+            )
+        ),
+    ],
+) -> str:
+    """Look up a Joplin notebook's ID by name or hierarchical path.
+
+    Resolves a notebook name or '/'-separated path to its unique Joplin ID and
+    returns the ID together with the notebook's title and full path for
+    confirmation.
+
+    Supports:
+    - Exact title match: ``get_folder_id("Work")``
+    - Hierarchical path match: ``get_folder_id("Projects/Work/Tasks")``
+
+    Returns:
+        str: Formatted block containing the resolved notebook ID, title, and
+        full path, or an error message if the notebook was not found.
+
+    Examples:
+        - get_folder_id("Work") - Find a top-level notebook by title
+        - get_folder_id("Professional & Knowledge/Claude Code") - Find by path
+    """
+    notebook_id = get_notebook_id_by_name(name)
+    nb_map = get_notebook_map_cached()
+    full_path = _compute_notebook_path(notebook_id, nb_map)
+    title = (nb_map.get(notebook_id) or {}).get("title") or name
+
+    return (
+        f"Notebook found:\n"
+        f"  ID:    {notebook_id}\n"
+        f"  Title: {title}\n"
+        f"  Path:  {full_path}"
+    )

--- a/tests/test_tools_notebooks.py
+++ b/tests/test_tools_notebooks.py
@@ -218,6 +218,77 @@ class TestDeleteNotebookTool:
         mock_invalidate.assert_called_once()
 
 
+# === Tests for get_folder_id tool ===
+
+
+class TestGetFolderIdTool:
+    """Tests for get_folder_id tool."""
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notebooks._compute_notebook_path")
+    @patch("joplin_mcp.tools.notebooks.get_notebook_map_cached")
+    @patch("joplin_mcp.tools.notebooks.get_notebook_id_by_name")
+    async def test_returns_id_title_and_path(
+        self, mock_get_id, mock_get_map, mock_compute_path
+    ):
+        """Should return notebook ID, title and full path."""
+        from joplin_mcp.tools.notebooks import get_folder_id
+
+        mock_get_id.return_value = "abc123def456"
+        mock_get_map.return_value = {
+            "abc123def456": {"title": "Work", "parent_id": None}
+        }
+        mock_compute_path.return_value = "Work"
+
+        fn = _get_tool_fn(get_folder_id)
+        result = await fn(name="Work")
+
+        mock_get_id.assert_called_once_with("Work")
+        mock_compute_path.assert_called_once()
+        assert "abc123def456" in result
+        assert "Work" in result
+        assert "ID:" in result
+        assert "Title:" in result
+        assert "Path:" in result
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notebooks._compute_notebook_path")
+    @patch("joplin_mcp.tools.notebooks.get_notebook_map_cached")
+    @patch("joplin_mcp.tools.notebooks.get_notebook_id_by_name")
+    async def test_hierarchical_path_resolution(
+        self, mock_get_id, mock_get_map, mock_compute_path
+    ):
+        """Should resolve nested notebook path."""
+        from joplin_mcp.tools.notebooks import get_folder_id
+
+        mock_get_id.return_value = "nested_nb_id"
+        mock_get_map.return_value = {
+            "parent_id": {"title": "Professional & Knowledge", "parent_id": None},
+            "nested_nb_id": {"title": "Claude Code", "parent_id": "parent_id"},
+        }
+        mock_compute_path.return_value = "Professional & Knowledge/Claude Code"
+
+        fn = _get_tool_fn(get_folder_id)
+        result = await fn(name="Professional & Knowledge/Claude Code")
+
+        mock_get_id.assert_called_once_with("Professional & Knowledge/Claude Code")
+        assert "nested_nb_id" in result
+        assert "Claude Code" in result
+        assert "Professional & Knowledge/Claude Code" in result
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notebooks.get_notebook_id_by_name")
+    async def test_raises_on_not_found(self, mock_get_id):
+        """Should propagate ValueError when notebook not found."""
+        from joplin_mcp.tools.notebooks import get_folder_id
+
+        mock_get_id.side_effect = ValueError("Notebook 'NoSuchFolder' not found")
+
+        fn = _get_tool_fn(get_folder_id)
+        with pytest.raises(ValueError, match="not found"):
+            await fn(name="NoSuchFolder")
+
+
 # === Integration tests for cache invalidation ===
 
 


### PR DESCRIPTION
Adds a new MCP tool that resolves a notebook name or hierarchical path (e.g. 'Projects/Work') to its Joplin folder ID. Uses the existing get_notebook_id_by_name() helper which supports both exact title match and '/'-separated path resolution.