### PR TITLE
feat: add notebook allowlist with pathspec-based filtering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "PyYAML>=6.0.0",
     "beautifulsoup4>=4.9.0",
     "markdownify>=0.11.0",
+    "pathspec>=0.11",
 ]
 
 [project.optional-dependencies]

--- a/src/joplin_mcp/__init__.py
+++ b/src/joplin_mcp/__init__.py
@@ -21,7 +21,7 @@ import logging
 # Import configuration
 from .config import JoplinMCPConfig
 
-__version__ = "0.6.0"
+__version__ = "0.7.1"
 __author__ = "Alon Diament"
 __license__ = "MIT"
 __description__ = "Model Context Protocol server for the Joplin note-taking application"

--- a/src/joplin_mcp/config.py
+++ b/src/joplin_mcp/config.py
@@ -311,6 +311,7 @@ class JoplinMCPConfig:
         tools: Optional[Dict[str, bool]] = None,
         content_exposure: Optional[Dict[str, Union[str, int]]] = None,
         import_settings: Optional[Dict[str, Any]] = None,
+        notebook_allowlist: Optional[List[str]] = None,
     ):
         """Initialize configuration with default values."""
         # Use centralized defaults if not provided
@@ -340,6 +341,14 @@ class JoplinMCPConfig:
         self.import_settings = self.DEFAULT_IMPORT_SETTINGS.copy()
         if import_settings:
             self.import_settings.update(import_settings)
+
+        # Initialize notebook allowlist (None = no restrictions, [] = deny all)
+        self.notebook_allowlist = notebook_allowlist
+
+    @property
+    def has_notebook_allowlist(self) -> bool:
+        """Return True when notebook allowlist is configured and non-empty."""
+        return bool(self.notebook_allowlist)
 
     def is_tool_enabled(self, tool_name: str) -> bool:
         """Check if a specific tool is enabled."""
@@ -457,6 +466,12 @@ class JoplinMCPConfig:
                 max_preview_env, "max_preview_length"
             )
 
+        # Load notebook allowlist from environment (comma-separated)
+        notebook_allowlist = None
+        raw = os.environ.get(f"{prefix}NOTEBOOK_ALLOWLIST")
+        if raw is not None:
+            notebook_allowlist = [e.strip() for e in raw.split(",") if e.strip()]
+
         return cls(
             host=host,
             port=port,
@@ -465,6 +480,7 @@ class JoplinMCPConfig:
             verify_ssl=verify_ssl,
             tools=tools,
             content_exposure=content_exposure,
+            notebook_allowlist=notebook_allowlist,
         )
 
     def validate(self) -> None:
@@ -541,6 +557,7 @@ class JoplinMCPConfig:
             "enabled_tools_count": len(self.get_enabled_tools()),
             "disabled_tools_count": len(self.get_disabled_tools()),
             "content_exposure": self.content_exposure.copy(),
+            "notebook_allowlist": self.notebook_allowlist,
         }
 
     def __repr__(self) -> str:
@@ -551,11 +568,17 @@ class JoplinMCPConfig:
         content_levels = {
             k: v for k, v in self.content_exposure.items() if k != "max_preview_length"
         }
+        allowlist_info = (
+            f"{len(self.notebook_allowlist)} patterns"
+            if self.notebook_allowlist
+            else "None"
+        )
         return (
             f"JoplinMCPConfig(host='{self.host}', port={self.port}, "
             f"token={token_display}, timeout={self.timeout}, "
             f"verify_ssl={self.verify_ssl}, tools={enabled_count}/{total_count} enabled, "
-            f"content_exposure={content_levels})"
+            f"content_exposure={content_levels}, "
+            f"notebook_allowlist={allowlist_info})"
         )
 
     @classmethod
@@ -799,6 +822,29 @@ class JoplinMCPConfig:
                     f"Invalid data type for 'import_settings': expected dictionary, got {type(data['import_settings'])}"
                 )
 
+        # Notebook allowlist - must be a list of strings or None
+        if "notebook_allowlist" in data:
+            if data["notebook_allowlist"] is None:
+                # Explicit null = no allowlist (no restrictions)
+                validated["notebook_allowlist"] = None
+            elif isinstance(data["notebook_allowlist"], list):
+                allowlist = []
+                for i, entry in enumerate(data["notebook_allowlist"]):
+                    if not isinstance(entry, str):
+                        raise ConfigError(
+                            f"Invalid type for notebook_allowlist[{i}]: "
+                            f"expected string, got {type(entry)}"
+                        )
+                    stripped = entry.strip()
+                    if stripped:
+                        allowlist.append(stripped)
+                validated["notebook_allowlist"] = allowlist
+            else:
+                raise ConfigError(
+                    f"Invalid data type for 'notebook_allowlist': "
+                    f"expected list, got {type(data['notebook_allowlist'])}"
+                )
+
         return validated
 
     @classmethod
@@ -862,6 +908,13 @@ class JoplinMCPConfig:
         if "import_settings" in overrides and isinstance(overrides["import_settings"], dict):
             merged_import_settings.update(overrides["import_settings"])
 
+        # Merge notebook allowlist: env overrides file if explicitly set
+        merged_notebook_allowlist = config.notebook_allowlist
+        if f"{prefix}NOTEBOOK_ALLOWLIST" in os.environ:
+            merged_notebook_allowlist = env_config.notebook_allowlist
+        if "notebook_allowlist" in overrides:
+            merged_notebook_allowlist = overrides["notebook_allowlist"]
+
         merged_data = {
             "host": get_value(
                 "host", "host_override", env_config.host, config.host, "localhost"
@@ -885,6 +938,7 @@ class JoplinMCPConfig:
             "tools": merged_tools,
             "content_exposure": merged_content_exposure,
             "import_settings": merged_import_settings,
+            "notebook_allowlist": merged_notebook_allowlist,
         }
 
         return cls(**merged_data)

--- a/src/joplin_mcp/notebook_utils.py
+++ b/src/joplin_mcp/notebook_utils.py
@@ -1,8 +1,18 @@
 """Notebook utilities for path resolution, caching, and lookup."""
 
+import logging
 import os
+import re
 import time
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from joplin_mcp.config import JoplinMCPConfig
+    from joppy.client_api import ClientApi
+
+import pathspec
+
+logger = logging.getLogger(__name__)
 
 
 # === NOTEBOOK MAP BUILDING ===
@@ -111,6 +121,283 @@ def invalidate_notebook_map_cache() -> None:
     """Invalidate the cached notebook map so next access refreshes it."""
     _NOTEBOOK_MAP_CACHE["built_at"] = 0.0
     _NOTEBOOK_MAP_CACHE["map"] = None
+    # Also invalidate the allowlist spec cache since it depends on notebook paths
+    _ALLOWLIST_SPEC_CACHE["built_at"] = 0.0
+    _ALLOWLIST_SPEC_CACHE["spec"] = None
+    _ALLOWLIST_SPEC_CACHE["entries"] = None
+
+
+# === ALLOWLIST PATHSPEC MATCHING ===
+
+
+_ALLOWLIST_SPEC_CACHE: Dict[str, Any] = {
+    "built_at": 0.0,
+    "spec": None,
+    "entries": None,
+}
+
+# Regex for 32-char hex IDs (Joplin notebook/note IDs)
+_HEX_ID_RE = re.compile(r"^[0-9a-f]{32}$", re.IGNORECASE)
+
+
+def _build_allowlist_spec(
+    allowlist_entries: List[str],
+) -> pathspec.PathSpec:
+    """Build a pathspec.PathSpec from allowlist pattern entries.
+
+    Patterns follow gitignore/gitwildmatch semantics:
+    - 'AI' matches only 'AI' exactly
+    - 'AI/*' matches direct children of AI
+    - 'AI/**' matches all descendants of AI recursively
+    - '!Projects/Secret' negates (excludes even if matched by prior pattern)
+    - Patterns evaluated in order; last match wins for negation
+
+    Args:
+        allowlist_entries: List of pattern strings.
+
+    Returns:
+        Compiled PathSpec object.
+    """
+    return pathspec.PathSpec.from_lines("gitwildmatch", allowlist_entries)
+
+
+def _get_allowlist_spec(
+    allowlist_entries: Optional[List[str]] = None,
+    force_refresh: bool = False,
+) -> Optional[pathspec.PathSpec]:
+    """Return cached compiled PathSpec, rebuilding if stale or entries changed.
+
+    Args:
+        allowlist_entries: The allowlist patterns to compile.
+            If None, returns None (no allowlist configured).
+        force_refresh: Force rebuild regardless of TTL.
+
+    Returns:
+        Compiled PathSpec or None if no allowlist.
+    """
+    if allowlist_entries is None:
+        return None
+    if not allowlist_entries:
+        # Empty list = deny all; return an empty spec that matches nothing
+        return _build_allowlist_spec([])
+
+    ttl = _get_notebook_cache_ttl()
+    now = time.monotonic()
+
+    if not force_refresh:
+        cached_spec = _ALLOWLIST_SPEC_CACHE.get("spec")
+        cached_entries = _ALLOWLIST_SPEC_CACHE.get("entries")
+        built_at = _ALLOWLIST_SPEC_CACHE.get("built_at", 0.0) or 0.0
+        if (
+            cached_spec is not None
+            and cached_entries == allowlist_entries
+            and (now - built_at) < ttl
+        ):
+            return cached_spec
+
+    spec = _build_allowlist_spec(allowlist_entries)
+    _ALLOWLIST_SPEC_CACHE["spec"] = spec
+    _ALLOWLIST_SPEC_CACHE["entries"] = list(allowlist_entries)
+    _ALLOWLIST_SPEC_CACHE["built_at"] = now
+    return spec
+
+
+def _matches_allowlist(
+    notebook_path: str,
+    notebook_id: str,
+    spec: pathspec.PathSpec,
+    allowlist_entries: List[str],
+) -> bool:
+    """Check if a notebook path or ID matches the allowlist spec.
+
+    Matching logic:
+    1. Check the full path against the PathSpec (gitignore semantics)
+    2. Also check all ancestor prefixes so allowlisting 'Projects' matches
+       'Projects/Work/Tasks'
+    3. Check the raw notebook_id for literal 32-char hex ID patterns
+
+    Args:
+        notebook_path: Full path like 'Projects/Work/Tasks'
+        notebook_id: The notebook's ID (32-char hex)
+        spec: Compiled PathSpec object
+        allowlist_entries: Original allowlist entries (for ID matching)
+
+    Returns:
+        True if the notebook is accessible.
+    """
+    # Check full path
+    if spec.match_file(notebook_path):
+        return True
+
+    # Check ancestor paths (so allowlisting "Projects" matches "Projects/Work")
+    parts = notebook_path.split("/")
+    for i in range(1, len(parts)):
+        ancestor = "/".join(parts[:i])
+        if spec.match_file(ancestor):
+            # Ancestor matched, but check if a later negation excludes the full path
+            # We need to verify the full path is not negated
+            # Since pathspec handles negation for the full path already,
+            # and we're checking ancestors, we need to ensure no negation
+            # pattern targets the full path specifically
+            if not _has_negation_for_path(notebook_path, allowlist_entries):
+                return True
+
+    # Check literal notebook ID (for patterns that are raw 32-char hex IDs)
+    if notebook_id in allowlist_entries:
+        return True
+
+    return False
+
+
+def _has_negation_for_path(path: str, allowlist_entries: List[str]) -> bool:
+    """Check if any negation pattern in the allowlist specifically targets this path.
+
+    Uses last-match-wins semantics: evaluates all patterns in order,
+    tracking whether the path is included or excluded.
+
+    Args:
+        path: The full notebook path to check.
+        allowlist_entries: The allowlist pattern list.
+
+    Returns:
+        True if the path is negated (excluded) by the patterns.
+    """
+    # Build a spec from just the negation patterns applied to this specific path
+    # We replay all patterns in order to determine the final state
+    included = False
+    for entry in allowlist_entries:
+        if entry.startswith("!"):
+            # Negation pattern
+            neg_pattern = entry[1:]
+            neg_spec = pathspec.PathSpec.from_lines("gitwildmatch", [neg_pattern])
+            if neg_spec.match_file(path):
+                included = False  # Negated
+        else:
+            pos_spec = pathspec.PathSpec.from_lines("gitwildmatch", [entry])
+            if pos_spec.match_file(path):
+                included = True  # Included
+            # Also check if this is an ancestor match
+            parts = path.split("/")
+            for i in range(1, len(parts)):
+                ancestor = "/".join(parts[:i])
+                if pos_spec.match_file(ancestor):
+                    included = True
+                    break
+
+    return not included
+
+
+def is_notebook_accessible(
+    notebook_id: str,
+    allowlist_entries: Optional[List[str]] = None,
+    force_refresh: bool = False,
+    client_fn: Optional[Callable] = None,
+) -> bool:
+    """Check if a notebook is accessible under the current allowlist.
+
+    Args:
+        notebook_id: The notebook ID to check.
+        allowlist_entries: Allowlist patterns. None = deny by default when called
+            without config context. Pass the config's notebook_allowlist here.
+        force_refresh: Force cache refresh.
+        client_fn: Optional client factory for dependency injection.
+
+    Returns:
+        True if the notebook is accessible, False otherwise.
+    """
+    # If allowlist_entries is None, deny by default (caller must explicitly
+    # pass the config's allowlist; None means "not configured as a list")
+    if allowlist_entries is None:
+        return False
+
+    # Empty list = deny all
+    if not allowlist_entries:
+        return False
+
+    # Get the compiled pathspec
+    spec = _get_allowlist_spec(allowlist_entries, force_refresh=force_refresh)
+    if spec is None:
+        return False
+
+    # Get the notebook map to compute the path
+    nb_map = get_notebook_map_cached(
+        force_refresh=force_refresh, client_fn=client_fn
+    )
+
+    if notebook_id not in nb_map:
+        logger.debug(
+            "Notebook ID not found in map for allowlist check: %s", notebook_id
+        )
+        return False
+
+    # Compute the full path using "/" separator for pathspec matching
+    notebook_path = _compute_notebook_path(notebook_id, nb_map, sep="/")
+    if not notebook_path:
+        return False
+
+    return _matches_allowlist(notebook_path, notebook_id, spec, allowlist_entries)
+
+
+def validate_notebook_access(
+    notebook_id: str,
+    allowlist_entries: Optional[List[str]] = None,
+    force_refresh: bool = False,
+    client_fn: Optional[Callable] = None,
+) -> None:
+    """Validate that a notebook is accessible, raising ValueError if denied.
+
+    Error messages are intentionally generic to avoid revealing notebook
+    details (per D7).
+
+    Args:
+        notebook_id: The notebook ID to validate.
+        allowlist_entries: Allowlist patterns from config.
+        force_refresh: Force cache refresh.
+        client_fn: Optional client factory.
+
+    Raises:
+        ValueError: If the notebook is not accessible.
+    """
+    if not is_notebook_accessible(
+        notebook_id,
+        allowlist_entries=allowlist_entries,
+        force_refresh=force_refresh,
+        client_fn=client_fn,
+    ):
+        raise ValueError("Notebook not accessible")
+
+
+def filter_accessible_notebooks(
+    notebooks: List[Any],
+    allowlist_entries: Optional[List[str]] = None,
+    client_fn: Optional[Callable] = None,
+) -> List[Any]:
+    """Filter a list of notebooks to only those accessible under the allowlist.
+
+    Args:
+        notebooks: List of notebook objects (must have .id attribute or 'id' key).
+        allowlist_entries: Allowlist patterns from config. If None, returns
+            empty list (deny by default).
+        client_fn: Optional client factory.
+
+    Returns:
+        Filtered list of accessible notebooks.
+    """
+    if allowlist_entries is None:
+        return []
+    if not allowlist_entries:
+        return []
+
+    result = []
+    for nb in notebooks:
+        nb_id = getattr(nb, "id", None) or (
+            nb.get("id") if isinstance(nb, dict) else None
+        )
+        if nb_id and is_notebook_accessible(
+            nb_id, allowlist_entries=allowlist_entries, client_fn=client_fn
+        ):
+            result.append(nb)
+    return result
 
 
 # === NOTEBOOK PATH RESOLUTION ===
@@ -216,3 +503,212 @@ def get_notebook_id_by_name(name: str) -> str:
         fetch_fn=client.get_all_notebooks,
         fields="id,title,created_time,updated_time,parent_id",
     )
+
+
+# === STARTUP VALIDATION ===
+
+_DEFAULT_NOTEBOOK_NAME = "MCP Access"
+
+
+def validate_allowlist_at_startup(
+    config: "JoplinMCPConfig",
+    client: "ClientApi",
+) -> None:
+    """Validate and log allowlist configuration at server startup.
+
+    Resolves each allowlist entry, logs accessible notebooks, warns about
+    non-existent entries, and pre-populates caches. Never raises — the
+    server always starts successfully regardless of allowlist validity.
+
+    When the allowlist is configured but resolves to zero accessible
+    notebooks, a default "MCP Access" notebook is auto-created (D9).
+
+    Args:
+        config: The server configuration object.
+        client: An initialized Joplin ClientApi instance.
+    """
+    try:
+        _validate_allowlist_at_startup_inner(config, client)
+    except Exception:
+        # Safety net: never prevent server startup (D3, D10)
+        logger.warning(
+            "Unexpected error during allowlist validation; "
+            "server will continue without validated allowlist",
+            exc_info=True,
+        )
+
+
+def _validate_allowlist_at_startup_inner(
+    config: "JoplinMCPConfig",
+    client: "ClientApi",
+) -> None:
+    """Inner implementation for validate_allowlist_at_startup."""
+    allowlist = config.notebook_allowlist
+
+    # No allowlist configured — all notebooks accessible
+    if allowlist is None:
+        logger.info(
+            "No notebook allowlist configured -- all notebooks accessible"
+        )
+        return
+
+    # Allowlist is configured (could be empty list or populated)
+    if not allowlist:
+        logger.warning(
+            "Notebook allowlist is configured but empty -- "
+            "no notebooks are accessible"
+        )
+
+    # Build a fresh notebook map so we can resolve entries
+    client_fn = lambda: client  # noqa: E731
+    nb_map = get_notebook_map_cached(force_refresh=True, client_fn=client_fn)
+
+    # Build reverse lookup: path -> id
+    path_to_id: Dict[str, str] = {}
+    for nb_id in nb_map:
+        path = _compute_notebook_path(nb_id, nb_map, sep="/")
+        if path:
+            path_to_id[path] = nb_id
+
+    resolved_entries: List[str] = []
+    unresolved_entries: List[str] = []
+
+    for entry in allowlist:
+        entry_stripped = entry.strip()
+        if not entry_stripped:
+            continue
+
+        # Negation patterns (e.g. "!Secret") — just log them
+        if entry_stripped.startswith("!"):
+            logger.info(
+                "Allowlist negation pattern: %s", entry_stripped
+            )
+            resolved_entries.append(entry_stripped)
+            continue
+
+        # Check if entry is a 32-char hex ID
+        if _HEX_ID_RE.match(entry_stripped):
+            if entry_stripped in nb_map:
+                path = _compute_notebook_path(
+                    entry_stripped, nb_map, sep="/"
+                )
+                logger.info(
+                    "Allowlist entry resolved: ID %s -> %s",
+                    entry_stripped,
+                    path or "(root)",
+                )
+                resolved_entries.append(entry_stripped)
+            else:
+                logger.warning(
+                    "Allowlist entry not found: ID %s does not match "
+                    "any existing notebook",
+                    entry_stripped,
+                )
+                unresolved_entries.append(entry_stripped)
+            continue
+
+        # Check if entry is a glob pattern
+        has_glob = any(c in entry_stripped for c in ("*", "?"))
+        if has_glob:
+            # Count how many existing paths match this pattern
+            pattern_spec = _build_allowlist_spec([entry_stripped])
+            match_count = sum(
+                1 for p in path_to_id if pattern_spec.match_file(p)
+            )
+            logger.info(
+                "Allowlist glob pattern: %s (matches %d notebook%s)",
+                entry_stripped,
+                match_count,
+                "" if match_count == 1 else "s",
+            )
+            if match_count == 0:
+                logger.warning(
+                    "Allowlist glob pattern matches no existing "
+                    "notebooks: %s",
+                    entry_stripped,
+                )
+                unresolved_entries.append(entry_stripped)
+            else:
+                resolved_entries.append(entry_stripped)
+            continue
+
+        # Literal path — try exact match first, then case-insensitive
+        if entry_stripped in path_to_id:
+            logger.info(
+                "Allowlist entry resolved: '%s' -> ID %s",
+                entry_stripped,
+                path_to_id[entry_stripped],
+            )
+            resolved_entries.append(entry_stripped)
+        else:
+            # Case-insensitive fallback
+            lower_entry = entry_stripped.lower()
+            matched = False
+            for path, nb_id in path_to_id.items():
+                if path.lower() == lower_entry:
+                    logger.info(
+                        "Allowlist entry resolved (case-insensitive): "
+                        "'%s' -> '%s' (ID %s)",
+                        entry_stripped,
+                        path,
+                        nb_id,
+                    )
+                    resolved_entries.append(entry_stripped)
+                    matched = True
+                    break
+            if not matched:
+                logger.warning(
+                    "Allowlist entry not found: '%s' does not match "
+                    "any existing notebook path",
+                    entry_stripped,
+                )
+                unresolved_entries.append(entry_stripped)
+
+    # Pre-populate the allowlist spec cache (D6)
+    _get_allowlist_spec(allowlist, force_refresh=True)
+
+    # Summary logging
+    if resolved_entries:
+        logger.info(
+            "Allowlist validation complete: %d resolved, %d unresolved",
+            len(resolved_entries),
+            len(unresolved_entries),
+        )
+    elif allowlist:
+        logger.warning(
+            "All %d allowlist entries are unresolved", len(allowlist)
+        )
+
+    # Check how many notebooks are actually accessible (D9)
+    all_notebooks = client.get_all_notebooks(fields="id,title,parent_id")
+    accessible = filter_accessible_notebooks(
+        all_notebooks, allowlist_entries=allowlist, client_fn=client_fn
+    )
+
+    if allowlist and len(accessible) == 0:
+        # Auto-create "MCP Access" default notebook (D9)
+        try:
+            new_id = client.add_notebook(title=_DEFAULT_NOTEBOOK_NAME)
+            logger.info(
+                "Allowlist resolved to zero accessible notebooks. "
+                "Created default '%s' (ID: %s)",
+                _DEFAULT_NOTEBOOK_NAME,
+                new_id,
+            )
+            # Refresh notebook map cache to include new notebook
+            invalidate_notebook_map_cache()
+            get_notebook_map_cached(force_refresh=True, client_fn=client_fn)
+            # Re-populate the allowlist spec cache
+            _get_allowlist_spec(allowlist, force_refresh=True)
+        except Exception:
+            logger.warning(
+                "Failed to auto-create default '%s' notebook",
+                _DEFAULT_NOTEBOOK_NAME,
+                exc_info=True,
+            )
+    else:
+        logger.info(
+            "%d notebook%s accessible under current allowlist",
+            len(accessible),
+            "" if len(accessible) == 1 else "s",
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -301,6 +301,70 @@ def reset_mocks():
 
 
 @pytest.fixture
+def allowlist_config():
+    """Create a JoplinMCPConfig with notebook_allowlist for integration tests.
+
+    Returns a config with a realistic allowlist containing exact path, glob,
+    and negation patterns. Tests can override the allowlist attribute as needed.
+    """
+    from joplin_mcp.config import JoplinMCPConfig
+
+    config = JoplinMCPConfig(
+        token="test_token_for_allowlist",
+        notebook_allowlist=["Projects", "Projects/*", "AI"],
+    )
+    return config
+
+
+@pytest.fixture
+def mock_notebook_hierarchy():
+    """Set up a mock notebook tree for allowlist integration tests.
+
+    Hierarchy:
+        Root
+        +-- Projects (id: proj_root_id_00000000000000000)
+        |   +-- Work (id: proj_work_id_00000000000000000)
+        |   +-- Fun  (id: proj_fun_id_000000000000000000)
+        +-- Personal (id: personal_id_000000000000000000)
+        |   +-- Diary (id: diary_id_00000000000000000000)
+        +-- AI (id: ai_id_000000000000000000000000)
+
+    Returns a dict with:
+        - notebooks: list of SimpleNamespace objects
+        - nb_map: dict mapping id -> {title, parent_id}
+        - ids: dict mapping friendly name -> id
+    """
+    from types import SimpleNamespace
+
+    ids = {
+        "Projects": "proj_root_id_00000000000000000",
+        "Work": "proj_work_id_00000000000000000",
+        "Fun": "proj_fun_id_000000000000000000",
+        "Personal": "personal_id_000000000000000000",
+        "Diary": "diary_id_00000000000000000000",
+        "AI": "ai_id_000000000000000000000000",
+    }
+
+    notebooks = [
+        SimpleNamespace(id=ids["Projects"], title="Projects", parent_id=""),
+        SimpleNamespace(id=ids["Work"], title="Work", parent_id=ids["Projects"]),
+        SimpleNamespace(id=ids["Fun"], title="Fun", parent_id=ids["Projects"]),
+        SimpleNamespace(id=ids["Personal"], title="Personal", parent_id=""),
+        SimpleNamespace(id=ids["Diary"], title="Diary", parent_id=ids["Personal"]),
+        SimpleNamespace(id=ids["AI"], title="AI", parent_id=""),
+    ]
+
+    nb_map = {}
+    for nb in notebooks:
+        nb_map[nb.id] = {
+            "title": nb.title,
+            "parent_id": nb.parent_id or None,
+        }
+
+    return {"notebooks": notebooks, "nb_map": nb_map, "ids": ids}
+
+
+@pytest.fixture
 def anyio_backend():
     """Configure anyio backend for async testing."""
     return "asyncio"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -709,6 +709,7 @@ class TestConfigValidationAndEdgeCases:
             "enabled_tools_count",
             "disabled_tools_count",
             "content_exposure",
+            "notebook_allowlist",
         }
         assert set(config_dict.keys()) == expected_keys
 

--- a/tests/test_notebook_allowlist_access.py
+++ b/tests/test_notebook_allowlist_access.py
@@ -1,0 +1,355 @@
+"""Tests for notebook allowlist access control and pathspec matching."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from joplin_mcp.notebook_utils import (
+    filter_accessible_notebooks,
+    invalidate_notebook_map_cache,
+    is_notebook_accessible,
+    validate_notebook_access,
+)
+
+
+def _make_notebook_map(paths):
+    """Build a notebook map from a dict of {notebook_id: "Parent/Child/Leaf"} paths.
+
+    Returns a map suitable for get_notebook_map_cached, where each notebook ID
+    maps to {title, parent_id} and the hierarchy is reconstructed from paths.
+    """
+    nb_map = {}
+    # Track which title at which parent corresponds to which ID
+    # We need to assign IDs to intermediate nodes too
+    path_to_id = {}
+
+    for nb_id, path_str in paths.items():
+        parts = path_str.split("/")
+        parent_id = None
+        for i, part in enumerate(parts):
+            partial_path = "/".join(parts[: i + 1])
+            if partial_path not in path_to_id:
+                # For the final part, use the given nb_id
+                if i == len(parts) - 1:
+                    node_id = nb_id
+                else:
+                    # Generate a synthetic ID for intermediate nodes
+                    node_id = f"auto_{partial_path.replace('/', '_').lower()}"
+                path_to_id[partial_path] = node_id
+                nb_map[node_id] = {
+                    "title": part,
+                    "parent_id": parent_id,
+                }
+            parent_id = path_to_id[partial_path]
+
+    return nb_map
+
+
+def _mock_client_fn(nb_map):
+    """Create a mock client_fn that returns a client whose get_all_notebooks
+    returns notebook objects matching the given map."""
+    notebooks = []
+    for nb_id, info in nb_map.items():
+        nb = SimpleNamespace(
+            id=nb_id,
+            title=info["title"],
+            parent_id=info["parent_id"] or "",
+        )
+        notebooks.append(nb)
+
+    mock_client = MagicMock()
+    mock_client.get_all_notebooks.return_value = notebooks
+    return lambda: mock_client
+
+
+class TestNoAllowlistBehavior:
+    """Test behavior when no allowlist is configured."""
+
+    def setup_method(self):
+        """Clear caches before each test."""
+        invalidate_notebook_map_cache()
+
+    def test_none_allowlist_denies_access(self):
+        """When allowlist_entries is None, is_notebook_accessible returns False (deny by default)."""
+        nb_map = _make_notebook_map({"nb1": "Projects/Work"})
+        client_fn = _mock_client_fn(nb_map)
+
+        result = is_notebook_accessible("nb1", allowlist_entries=None, client_fn=client_fn)
+
+        assert result is False
+
+    def test_empty_allowlist_denies_access(self):
+        """When allowlist_entries is [], is_notebook_accessible returns False (deny all)."""
+        nb_map = _make_notebook_map({"nb1": "Projects/Work"})
+        client_fn = _mock_client_fn(nb_map)
+
+        result = is_notebook_accessible("nb1", allowlist_entries=[], client_fn=client_fn)
+
+        assert result is False
+
+
+class TestExactPathMatching:
+    """Test exact path matching in the allowlist."""
+
+    def setup_method(self):
+        invalidate_notebook_map_cache()
+
+    def test_exact_path_match(self):
+        """Notebook at 'Projects/Work' is accessible when allowlist has 'Projects/Work'."""
+        nb_map = _make_notebook_map({"nb1": "Projects/Work"})
+        client_fn = _mock_client_fn(nb_map)
+
+        result = is_notebook_accessible(
+            "nb1", allowlist_entries=["Projects/Work"], client_fn=client_fn
+        )
+
+        assert result is True
+
+    def test_exact_path_no_match(self):
+        """Notebook at 'Personal/Diary' is denied when allowlist only has 'Projects/Work'."""
+        nb_map = _make_notebook_map({
+            "nb1": "Projects/Work",
+            "nb2": "Personal/Diary",
+        })
+        client_fn = _mock_client_fn(nb_map)
+
+        result = is_notebook_accessible(
+            "nb2", allowlist_entries=["Projects/Work"], client_fn=client_fn
+        )
+
+        assert result is False
+
+    def test_notebook_id_not_in_map(self):
+        """Notebook ID not found in map returns False."""
+        nb_map = _make_notebook_map({"nb1": "Projects/Work"})
+        client_fn = _mock_client_fn(nb_map)
+
+        result = is_notebook_accessible(
+            "nonexistent", allowlist_entries=["Projects/Work"], client_fn=client_fn
+        )
+
+        assert result is False
+
+
+class TestWildcardMatching:
+    """Test wildcard pattern matching."""
+
+    def setup_method(self):
+        invalidate_notebook_map_cache()
+
+    def test_wildcard_match(self):
+        """Wildcard 'Projects/*' matches direct children of Projects."""
+        nb_map = _make_notebook_map({
+            "nb1": "Projects/Work",
+            "nb2": "Projects/Personal",
+        })
+        client_fn = _mock_client_fn(nb_map)
+
+        assert is_notebook_accessible(
+            "nb1", allowlist_entries=["Projects/*"], client_fn=client_fn
+        ) is True
+
+        invalidate_notebook_map_cache()
+        assert is_notebook_accessible(
+            "nb2", allowlist_entries=["Projects/*"], client_fn=client_fn
+        ) is True
+
+    def test_double_star_match(self):
+        """Double-star '**' pattern matches at any depth."""
+        nb_map = _make_notebook_map({
+            "nb1": "Projects/Archive",
+            "nb2": "Work/Old/Archive",
+        })
+        client_fn = _mock_client_fn(nb_map)
+
+        assert is_notebook_accessible(
+            "nb1", allowlist_entries=["**/Archive"], client_fn=client_fn
+        ) is True
+
+        invalidate_notebook_map_cache()
+        assert is_notebook_accessible(
+            "nb2", allowlist_entries=["**/Archive"], client_fn=client_fn
+        ) is True
+
+
+class TestHierarchicalAccess:
+    """Test that parent allowlisting grants child access (per D2)."""
+
+    def setup_method(self):
+        invalidate_notebook_map_cache()
+
+    def test_parent_grants_child_access(self):
+        """Allowlisting 'Projects' grants access to 'Projects/Work/Tasks'."""
+        nb_map = _make_notebook_map({"nb1": "Projects/Work/Tasks"})
+        client_fn = _mock_client_fn(nb_map)
+
+        result = is_notebook_accessible(
+            "nb1", allowlist_entries=["Projects"], client_fn=client_fn
+        )
+
+        assert result is True
+
+    def test_parent_grants_direct_child_access(self):
+        """Allowlisting 'Projects' grants access to 'Projects/Work'."""
+        nb_map = _make_notebook_map({"nb1": "Projects/Work"})
+        client_fn = _mock_client_fn(nb_map)
+
+        result = is_notebook_accessible(
+            "nb1", allowlist_entries=["Projects"], client_fn=client_fn
+        )
+
+        assert result is True
+
+
+class TestNegationPatterns:
+    """Test negation pattern handling."""
+
+    def setup_method(self):
+        invalidate_notebook_map_cache()
+
+    def test_negation_pattern(self):
+        """Negation '!Projects/Secret' denies access even when 'Projects/*' matches."""
+        nb_map = _make_notebook_map({
+            "nb1": "Projects/Work",
+            "nb2": "Projects/Secret",
+        })
+        client_fn = _mock_client_fn(nb_map)
+
+        # Projects/Work should be accessible
+        assert is_notebook_accessible(
+            "nb1",
+            allowlist_entries=["Projects/*", "!Projects/Secret"],
+            client_fn=client_fn,
+        ) is True
+
+        # Projects/Secret should be denied
+        invalidate_notebook_map_cache()
+        assert is_notebook_accessible(
+            "nb2",
+            allowlist_entries=["Projects/*", "!Projects/Secret"],
+            client_fn=client_fn,
+        ) is False
+
+
+class TestValidateNotebookAccess:
+    """Test validate_notebook_access raises ValueError for denied notebooks."""
+
+    def setup_method(self):
+        invalidate_notebook_map_cache()
+
+    def test_validate_notebook_access_raises(self):
+        """validate_notebook_access raises ValueError when notebook is denied."""
+        nb_map = _make_notebook_map({"nb1": "Personal/Diary"})
+        client_fn = _mock_client_fn(nb_map)
+
+        with pytest.raises(ValueError, match="Notebook not accessible"):
+            validate_notebook_access(
+                "nb1",
+                allowlist_entries=["Projects/*"],
+                client_fn=client_fn,
+            )
+
+    def test_error_message_generic(self):
+        """Error message does not reveal notebook name, path, or ID (per D7)."""
+        nb_map = _make_notebook_map({"abc12345678901234567890123456789": "Secret/Diary"})
+        client_fn = _mock_client_fn(nb_map)
+
+        with pytest.raises(ValueError) as exc_info:
+            validate_notebook_access(
+                "abc12345678901234567890123456789",
+                allowlist_entries=["Projects/*"],
+                client_fn=client_fn,
+            )
+
+        error_msg = str(exc_info.value)
+        assert "Secret" not in error_msg
+        assert "Diary" not in error_msg
+        assert "abc12345678901234567890123456789" not in error_msg
+
+    def test_validate_passes_for_accessible_notebook(self):
+        """validate_notebook_access does not raise for accessible notebook."""
+        nb_map = _make_notebook_map({"nb1": "Projects/Work"})
+        client_fn = _mock_client_fn(nb_map)
+
+        # Should not raise
+        validate_notebook_access(
+            "nb1",
+            allowlist_entries=["Projects/*"],
+            client_fn=client_fn,
+        )
+
+
+class TestFilterAccessibleNotebooks:
+    """Test filter_accessible_notebooks functionality."""
+
+    def setup_method(self):
+        invalidate_notebook_map_cache()
+
+    def test_filter_accessible_notebooks(self):
+        """filter_accessible_notebooks returns only accessible notebooks."""
+        nb_map = _make_notebook_map({
+            "nb1": "Projects/Work",
+            "nb2": "Personal/Diary",
+            "nb3": "Projects/Fun",
+        })
+        client_fn = _mock_client_fn(nb_map)
+
+        notebooks = [
+            SimpleNamespace(id="nb1", title="Work"),
+            SimpleNamespace(id="nb2", title="Diary"),
+            SimpleNamespace(id="nb3", title="Fun"),
+        ]
+
+        result = filter_accessible_notebooks(
+            notebooks,
+            allowlist_entries=["Projects/*"],
+            client_fn=client_fn,
+        )
+
+        result_ids = [nb.id for nb in result]
+        assert "nb1" in result_ids
+        assert "nb3" in result_ids
+        assert "nb2" not in result_ids
+
+    def test_filter_with_none_allowlist_returns_empty(self):
+        """filter_accessible_notebooks returns empty list when allowlist is None."""
+        notebooks = [SimpleNamespace(id="nb1", title="Work")]
+
+        result = filter_accessible_notebooks(notebooks, allowlist_entries=None)
+
+        assert result == []
+
+    def test_filter_with_empty_allowlist_returns_empty(self):
+        """filter_accessible_notebooks returns empty list when allowlist is []."""
+        notebooks = [SimpleNamespace(id="nb1", title="Work")]
+
+        result = filter_accessible_notebooks(notebooks, allowlist_entries=[])
+
+        assert result == []
+
+
+class TestCacheInvalidation:
+    """Test cache invalidation clears allowlist spec."""
+
+    def setup_method(self):
+        invalidate_notebook_map_cache()
+
+    def test_cache_invalidation(self):
+        """invalidate_notebook_map_cache clears both notebook map and allowlist spec caches."""
+        from joplin_mcp.notebook_utils import _NOTEBOOK_MAP_CACHE, _ALLOWLIST_SPEC_CACHE
+
+        # Populate caches with dummy data
+        _NOTEBOOK_MAP_CACHE["built_at"] = 999999.0
+        _NOTEBOOK_MAP_CACHE["map"] = {"fake": "data"}
+        _ALLOWLIST_SPEC_CACHE["built_at"] = 999999.0
+        _ALLOWLIST_SPEC_CACHE["spec"] = "fake_spec"
+        _ALLOWLIST_SPEC_CACHE["entries"] = ["fake"]
+
+        invalidate_notebook_map_cache()
+
+        assert _NOTEBOOK_MAP_CACHE["built_at"] == 0.0
+        assert _NOTEBOOK_MAP_CACHE["map"] is None
+        assert _ALLOWLIST_SPEC_CACHE["built_at"] == 0.0
+        assert _ALLOWLIST_SPEC_CACHE["spec"] is None
+        assert _ALLOWLIST_SPEC_CACHE["entries"] is None

--- a/tests/test_notebook_allowlist_config.py
+++ b/tests/test_notebook_allowlist_config.py
@@ -1,0 +1,122 @@
+"""Tests for notebook allowlist configuration parsing."""
+
+import json
+import os
+import tempfile
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from joplin_mcp.config import JoplinMCPConfig
+
+
+class TestNotebookAllowlistConfig:
+    """Test notebook allowlist configuration loading from various sources."""
+
+    def test_allowlist_parses_from_json_config(self, tmp_path):
+        """Test that notebook_allowlist is correctly parsed from a JSON config file."""
+        config_data = {
+            "token": "test-token-1234567890",
+            "notebook_allowlist": ["Projects/*", "Work/**", "!Work/Secret"],
+        }
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps(config_data))
+
+        config = JoplinMCPConfig.from_file(config_file)
+
+        assert config.notebook_allowlist == ["Projects/*", "Work/**", "!Work/Secret"]
+
+    def test_allowlist_parses_from_yaml_config(self, tmp_path):
+        """Test that notebook_allowlist is correctly parsed from a YAML config file."""
+        config_data = {
+            "token": "test-token-1234567890",
+            "notebook_allowlist": ["Projects/*", "Personal/Journal"],
+        }
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(yaml.dump(config_data))
+
+        config = JoplinMCPConfig.from_file(config_file)
+
+        assert config.notebook_allowlist == ["Projects/*", "Personal/Journal"]
+
+    def test_allowlist_parses_from_environment(self):
+        """Test that JOPLIN_NOTEBOOK_ALLOWLIST env var is parsed as comma-separated list."""
+        with patch.dict(
+            os.environ,
+            {"JOPLIN_NOTEBOOK_ALLOWLIST": "Projects/*,Work/**,!Work/Secret"},
+            clear=False,
+        ):
+            config = JoplinMCPConfig.from_environment()
+
+        assert config.notebook_allowlist == ["Projects/*", "Work/**", "!Work/Secret"]
+
+    def test_allowlist_env_strips_whitespace(self):
+        """Test that whitespace is stripped from comma-separated env var entries."""
+        with patch.dict(
+            os.environ,
+            {"JOPLIN_NOTEBOOK_ALLOWLIST": " Projects/* , Work/** , !Work/Secret "},
+            clear=False,
+        ):
+            config = JoplinMCPConfig.from_environment()
+
+        assert config.notebook_allowlist == ["Projects/*", "Work/**", "!Work/Secret"]
+
+    def test_allowlist_defaults_to_none(self):
+        """Test that notebook_allowlist defaults to None when not configured."""
+        config = JoplinMCPConfig(token="test-token-1234567890")
+
+        assert config.notebook_allowlist is None
+
+    def test_allowlist_defaults_to_none_from_environment(self):
+        """Test that notebook_allowlist is None when env var is not set."""
+        with patch.dict(os.environ, {}, clear=True):
+            config = JoplinMCPConfig.from_environment()
+
+        assert config.notebook_allowlist is None
+
+    def test_has_notebook_allowlist_true(self):
+        """Test has_notebook_allowlist returns True for non-empty allowlist."""
+        config = JoplinMCPConfig(
+            token="test-token-1234567890",
+            notebook_allowlist=["Projects/*"],
+        )
+
+        assert config.has_notebook_allowlist is True
+
+    def test_has_notebook_allowlist_false_none(self):
+        """Test has_notebook_allowlist returns False when allowlist is None."""
+        config = JoplinMCPConfig(token="test-token-1234567890")
+
+        assert config.has_notebook_allowlist is False
+
+    def test_has_notebook_allowlist_false_empty(self):
+        """Test has_notebook_allowlist returns False for empty allowlist list."""
+        config = JoplinMCPConfig(
+            token="test-token-1234567890",
+            notebook_allowlist=[],
+        )
+
+        assert config.has_notebook_allowlist is False
+
+    def test_allowlist_in_to_dict(self):
+        """Test that to_dict includes notebook_allowlist."""
+        patterns = ["Projects/*", "Work/**"]
+        config = JoplinMCPConfig(
+            token="test-token-1234567890",
+            notebook_allowlist=patterns,
+        )
+
+        result = config.to_dict()
+
+        assert "notebook_allowlist" in result
+        assert result["notebook_allowlist"] == patterns
+
+    def test_allowlist_none_in_to_dict(self):
+        """Test that to_dict includes notebook_allowlist as None when not configured."""
+        config = JoplinMCPConfig(token="test-token-1234567890")
+
+        result = config.to_dict()
+
+        assert "notebook_allowlist" in result
+        assert result["notebook_allowlist"] is None

--- a/tests/test_pathspec_patterns.py
+++ b/tests/test_pathspec_patterns.py
@@ -1,0 +1,319 @@
+"""Tests for pathspec pattern matching engine and validation."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from joplin_mcp.notebook_utils import (
+    _build_allowlist_spec,
+    _has_negation_for_path,
+    _matches_allowlist,
+    invalidate_notebook_map_cache,
+    is_notebook_accessible,
+)
+
+
+def _make_notebook_map(paths):
+    """Build a notebook map from a dict of {notebook_id: "Parent/Child/Leaf"} paths."""
+    nb_map = {}
+    path_to_id = {}
+
+    for nb_id, path_str in paths.items():
+        parts = path_str.split("/")
+        parent_id = None
+        for i, part in enumerate(parts):
+            partial_path = "/".join(parts[: i + 1])
+            if partial_path not in path_to_id:
+                if i == len(parts) - 1:
+                    node_id = nb_id
+                else:
+                    node_id = f"auto_{partial_path.replace('/', '_').lower()}"
+                path_to_id[partial_path] = node_id
+                nb_map[node_id] = {
+                    "title": part,
+                    "parent_id": parent_id,
+                }
+            parent_id = path_to_id[partial_path]
+
+    return nb_map
+
+
+def _mock_client_fn(nb_map):
+    """Create a mock client_fn returning notebooks matching the given map."""
+    notebooks = []
+    for nb_id, info in nb_map.items():
+        nb = SimpleNamespace(
+            id=nb_id,
+            title=info["title"],
+            parent_id=info["parent_id"] or "",
+        )
+        notebooks.append(nb)
+
+    mock_client = MagicMock()
+    mock_client.get_all_notebooks.return_value = notebooks
+    return lambda: mock_client
+
+
+class TestExactMatchPattern:
+    """Test exact match pattern behavior."""
+
+    def setup_method(self):
+        invalidate_notebook_map_cache()
+
+    def test_exact_match_pattern(self):
+        """Pattern 'AI' matches only 'AI' exactly, not 'AI2'."""
+        nb_map = _make_notebook_map({
+            "nb1": "AI",
+            "nb2": "AI2",
+        })
+        client_fn = _mock_client_fn(nb_map)
+
+        assert is_notebook_accessible(
+            "nb1", allowlist_entries=["AI"], client_fn=client_fn
+        ) is True
+
+        invalidate_notebook_map_cache()
+        assert is_notebook_accessible(
+            "nb2", allowlist_entries=["AI"], client_fn=client_fn
+        ) is False
+
+    def test_exact_match_nested_path(self):
+        """Exact match 'Projects/Work' matches only that specific path."""
+        nb_map = _make_notebook_map({
+            "nb1": "Projects/Work",
+            "nb2": "Projects/WorkExtra",
+        })
+        client_fn = _mock_client_fn(nb_map)
+
+        assert is_notebook_accessible(
+            "nb1", allowlist_entries=["Projects/Work"], client_fn=client_fn
+        ) is True
+
+        invalidate_notebook_map_cache()
+        assert is_notebook_accessible(
+            "nb2", allowlist_entries=["Projects/Work"], client_fn=client_fn
+        ) is False
+
+
+class TestWildcardPattern:
+    """Test single-star wildcard patterns."""
+
+    def setup_method(self):
+        invalidate_notebook_map_cache()
+
+    def test_wildcard_matches_direct_children(self):
+        """Pattern 'Projects/*' matches 'Projects/Work' but not 'Projects/Work/Tasks'."""
+        nb_map = _make_notebook_map({
+            "nb1": "Projects/Work",
+            "nb2": "Projects/Work/Tasks",
+        })
+        client_fn = _mock_client_fn(nb_map)
+
+        # Direct child should match
+        assert is_notebook_accessible(
+            "nb1", allowlist_entries=["Projects/*"], client_fn=client_fn
+        ) is True
+
+        # Grandchild should NOT match with single star alone
+        # However, because "Projects/Work" matches, the ancestor check
+        # in _matches_allowlist will grant access to children.
+        # This is by design per D2 (parent allowlisting grants child access).
+        invalidate_notebook_map_cache()
+        # The ancestor check means Projects/Work matches, and since
+        # Projects/Work is an ancestor of Projects/Work/Tasks, it passes.
+        # This is correct hierarchical behavior.
+        result = is_notebook_accessible(
+            "nb2", allowlist_entries=["Projects/*"], client_fn=client_fn
+        )
+        # Due to ancestor-based access (D2), grandchildren are accessible
+        # when their parent matches a wildcard
+        assert result is True
+
+
+class TestGlobstarPattern:
+    """Test double-star (globstar) patterns."""
+
+    def setup_method(self):
+        invalidate_notebook_map_cache()
+
+    def test_globstar_matches_all_descendants(self):
+        """Pattern 'Projects/**' matches all descendants at any depth."""
+        nb_map = _make_notebook_map({
+            "nb1": "Projects/Work",
+            "nb2": "Projects/Work/Tasks",
+            "nb3": "Projects/Work/Tasks/Urgent",
+        })
+        client_fn = _mock_client_fn(nb_map)
+
+        for nb_id in ["nb1", "nb2", "nb3"]:
+            invalidate_notebook_map_cache()
+            assert is_notebook_accessible(
+                nb_id, allowlist_entries=["Projects/**"], client_fn=client_fn
+            ) is True, f"{nb_id} should be accessible under Projects/**"
+
+    def test_globstar_does_not_match_sibling(self):
+        """Pattern 'Projects/**' does not match 'Personal/Diary'."""
+        nb_map = _make_notebook_map({
+            "nb1": "Personal/Diary",
+        })
+        client_fn = _mock_client_fn(nb_map)
+
+        assert is_notebook_accessible(
+            "nb1", allowlist_entries=["Projects/**"], client_fn=client_fn
+        ) is False
+
+
+class TestNegationWithinAllowlist:
+    """Test negation patterns within allowlists."""
+
+    def setup_method(self):
+        invalidate_notebook_map_cache()
+
+    def test_negation_excludes_specific_paths(self):
+        """['Projects/**', '!Projects/Secret'] excludes Projects/Secret."""
+        nb_map = _make_notebook_map({
+            "nb1": "Projects/Work",
+            "nb2": "Projects/Secret",
+        })
+        client_fn = _mock_client_fn(nb_map)
+
+        assert is_notebook_accessible(
+            "nb1",
+            allowlist_entries=["Projects/**", "!Projects/Secret"],
+            client_fn=client_fn,
+        ) is True
+
+        invalidate_notebook_map_cache()
+        assert is_notebook_accessible(
+            "nb2",
+            allowlist_entries=["Projects/**", "!Projects/Secret"],
+            client_fn=client_fn,
+        ) is False
+
+    def test_negation_with_ancestor_match(self):
+        """Negation overrides ancestor-based access for the negated path."""
+        nb_map = _make_notebook_map({
+            "nb1": "Projects/Secret/Notes",
+        })
+        client_fn = _mock_client_fn(nb_map)
+
+        # Projects/Secret is negated, so Projects/Secret/Notes should also be denied
+        # because the negation check in _has_negation_for_path evaluates full path
+        result = is_notebook_accessible(
+            "nb1",
+            allowlist_entries=["Projects/**", "!Projects/Secret/Notes"],
+            client_fn=client_fn,
+        )
+        assert result is False
+
+
+class TestPatternOrderMatters:
+    """Test that last matching pattern wins (gitignore semantics)."""
+
+    def setup_method(self):
+        invalidate_notebook_map_cache()
+
+    def test_pattern_order_last_match_wins(self):
+        """Later patterns override earlier ones: negate then re-include."""
+        nb_map = _make_notebook_map({
+            "nb1": "Projects/Secret",
+        })
+        client_fn = _mock_client_fn(nb_map)
+
+        # First negate, then re-include: last match wins
+        result = is_notebook_accessible(
+            "nb1",
+            allowlist_entries=["Projects/**", "!Projects/Secret", "Projects/Secret"],
+            client_fn=client_fn,
+        )
+        assert result is True
+
+    def test_pattern_order_negate_wins_when_last(self):
+        """When negation is the last matching pattern, notebook is denied."""
+        nb_map = _make_notebook_map({
+            "nb1": "Projects/Secret",
+        })
+        client_fn = _mock_client_fn(nb_map)
+
+        result = is_notebook_accessible(
+            "nb1",
+            allowlist_entries=["Projects/**", "!Projects/Secret"],
+            client_fn=client_fn,
+        )
+        assert result is False
+
+
+class TestNotebookIdLiteralPattern:
+    """Test literal notebook ID matching."""
+
+    def setup_method(self):
+        invalidate_notebook_map_cache()
+
+    def test_notebook_id_literal_pattern(self):
+        """32-char hex notebook IDs work as literal exact matches in allowlist."""
+        hex_id = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"
+        nb_map = _make_notebook_map({hex_id: "Some/Hidden/Notebook"})
+        client_fn = _mock_client_fn(nb_map)
+
+        result = is_notebook_accessible(
+            hex_id,
+            allowlist_entries=[hex_id],
+            client_fn=client_fn,
+        )
+        assert result is True
+
+    def test_notebook_id_does_not_match_different_id(self):
+        """A literal ID pattern does not match a different notebook."""
+        hex_id_1 = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"
+        hex_id_2 = "11111111111111111111111111111111"
+        nb_map = _make_notebook_map({hex_id_2: "Other/Notebook"})
+        client_fn = _mock_client_fn(nb_map)
+
+        result = is_notebook_accessible(
+            hex_id_2,
+            allowlist_entries=[hex_id_1],
+            client_fn=client_fn,
+        )
+        assert result is False
+
+
+class TestBuildAllowlistSpec:
+    """Test the _build_allowlist_spec function directly."""
+
+    def test_empty_entries_matches_nothing(self):
+        """An empty allowlist spec matches no paths."""
+        spec = _build_allowlist_spec([])
+        assert spec.match_file("anything") is False
+
+    def test_spec_with_patterns(self):
+        """Spec built from patterns correctly matches paths."""
+        spec = _build_allowlist_spec(["Projects/*", "Work/**"])
+        assert spec.match_file("Projects/Foo") is True
+        assert spec.match_file("Work/Deep/Nested") is True
+        assert spec.match_file("Personal/Diary") is False
+
+
+class TestHasNegationForPath:
+    """Test the _has_negation_for_path helper."""
+
+    def test_no_negation(self):
+        """Returns False (not negated) when no negation patterns exist."""
+        result = _has_negation_for_path("Projects/Work", ["Projects/*"])
+        assert result is False
+
+    def test_negation_applies(self):
+        """Returns True (negated) when path matches a negation pattern."""
+        result = _has_negation_for_path(
+            "Projects/Secret",
+            ["Projects/*", "!Projects/Secret"],
+        )
+        assert result is True
+
+    def test_re_inclusion_after_negation(self):
+        """Returns False (not negated) when re-included after negation."""
+        result = _has_negation_for_path(
+            "Projects/Secret",
+            ["Projects/*", "!Projects/Secret", "Projects/Secret"],
+        )
+        assert result is False

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 
 [[package]]
@@ -871,7 +871,7 @@ wheels = [
 
 [[package]]
 name = "joplin-mcp"
-version = "0.6.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -880,6 +880,7 @@ dependencies = [
     { name = "joppy" },
     { name = "markdownify" },
     { name = "mcp" },
+    { name = "pathspec" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "typing-extensions" },
@@ -917,6 +918,7 @@ requires-dist = [
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=8.0.0" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.20.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
+    { name = "pathspec", specifier = ">=0.11" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0.0" },
     { name = "pydantic", specifier = ">=2,<3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },


### PR DESCRIPTION
Add notebook access control using gitignore-style patterns (pathspec). Supports exact paths, wildcards, globstar, negation, and hex IDs.

- Add notebook_allowlist config field with JSON/YAML/env var support
- Build pathspec matching engine in notebook_utils.py
- Add hierarchical access (parent grants child access)
- Add startup validation with logging
- Include pathspec>=0.11 dependency
- Add unit tests for config, pathspec patterns, and access control