### PR TITLE
feat: add bulk operations, revision history, trash management, and database backup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "PyYAML>=6.0.0",
     "beautifulsoup4>=4.9.0",
     "markdownify>=0.11.0",
+    "diff-match-patch>=20230430",
 ]
 
 [project.optional-dependencies]

--- a/src/joplin_mcp/config.py
+++ b/src/joplin_mcp/config.py
@@ -229,6 +229,22 @@ class JoplinMCPConfig:
         "ping_joplin": True,  # Test connection
         # Import operations (1 tool)
         "import_from_file": False,  # Import single file or folder
+        # Bulk operations (6 tools)
+        "move_note": True,  # Move single note to different notebook
+        "bulk_move_notes": True,  # Bulk move (auto-backup before operation)
+        "search_and_bulk_update_preview": True,  # Preview bulk changes (read-only)
+        "search_and_bulk_update_execute": True,  # Execute bulk changes (preview required first, auto-backup)
+        "bulk_tag_notes": True,  # Bulk tag notes
+        "strip_note_tags": True,  # Remove all tags from a note
+        # Trash operations (2 tools)
+        "list_trash": True,  # List soft-deleted items
+        "restore_from_trash": True,  # Restore from trash
+        # Revision operations (3 tools)
+        "get_note_history": True,  # List note revisions
+        "restore_note_revision": True,  # Restore from revision (creates new note)
+        "manually_backup_note": True,  # Create revision snapshot
+        # Backup operations (1 tool)
+        "backup_database": True,  # SQLite database backup
     }
 
     # Tool categories for easier management
@@ -261,6 +277,26 @@ class JoplinMCPConfig:
         "utilities": ["ping_joplin"],
         "import": [
             "import_from_file",
+        ],
+        "bulk": [
+            "move_note",
+            "bulk_move_notes",
+            "search_and_bulk_update_preview",
+            "search_and_bulk_update_execute",
+            "bulk_tag_notes",
+            "strip_note_tags",
+        ],
+        "trash": [
+            "list_trash",
+            "restore_from_trash",
+        ],
+        "revisions": [
+            "get_note_history",
+            "restore_note_revision",
+            "manually_backup_note",
+        ],
+        "backup": [
+            "backup_database",
         ],
     }
 

--- a/src/joplin_mcp/formatting.py
+++ b/src/joplin_mcp/formatting.py
@@ -40,13 +40,19 @@ ITEM_ID: {item_id}
 MESSAGE: {item_type.value} updated successfully in Joplin"""
 
 
-def format_delete_success(item_type: ItemType, item_id: str) -> str:
+def format_delete_success(item_type: ItemType, item_id: str, soft_delete: bool = True) -> str:
     """Format a standardized success message for delete operations optimized for LLM comprehension."""
-    return f"""OPERATION: DELETE_{item_type.value.upper()}
+    if soft_delete:
+        operation = f"SOFT_DELETE_{item_type.value.upper()}"
+        message = f"{item_type.value} moved to trash in Joplin (recoverable via list_trash/restore_from_trash)"
+    else:
+        operation = f"DELETE_{item_type.value.upper()}"
+        message = f"{item_type.value} deleted permanently from Joplin"
+    return f"""OPERATION: {operation}
 STATUS: SUCCESS
 ITEM_TYPE: {item_type.value}
 ITEM_ID: {item_id}
-MESSAGE: {item_type.value} deleted successfully from Joplin"""
+MESSAGE: {message}"""
 
 
 def format_relation_success(

--- a/src/joplin_mcp/revision_utils.py
+++ b/src/joplin_mcp/revision_utils.py
@@ -1,0 +1,220 @@
+"""Revision utilities for creating and reconstructing Joplin note revisions.
+
+Provides diff-match-patch based revision creation (snapshots before destructive
+edits) and reconstruction (walking parent chains to rebuild content).
+Follows Joplin Desktop's createNoteRevision_ algorithm.
+"""
+
+import json
+import logging
+import time
+from typing import Any, Dict, Optional
+
+import diff_match_patch as dmp_module
+import joppy.data_types
+from joppy.client_api import ClientApi
+
+logger = logging.getLogger(__name__)
+
+# Module-level diff-match-patch instance and patch object type.
+# Use non-empty strings to avoid IndexError from patch_make('', '').
+_dmp = dmp_module.diff_match_patch()
+_PatchObj = type(_dmp.patch_make("", "x")[0])  # diff_match_patch.patch_obj
+
+
+def _apply_diff(diff_text: str, base: str) -> str:
+    """Apply a diff-match-patch diff to a base string.
+
+    Handles both Joplin's JSON format (starts with '[') and legacy format
+    (starts with '@@').
+
+    Args:
+        diff_text: The diff string in either JSON or legacy format.
+        base: The base string to apply the diff to.
+
+    Returns:
+        The patched string result.
+
+    Raises:
+        ValueError: If diff cannot be parsed or applied.
+    """
+    if not diff_text or diff_text == "[]":
+        return base
+
+    if diff_text.startswith("["):
+        # JSON format: list of patch dicts with diffs, start1/2, length1/2
+        patch_dicts = json.loads(diff_text)
+        patches = []
+        for pd in patch_dicts:
+            p = _PatchObj()
+            p.diffs = [tuple(d) for d in pd["diffs"]]
+            p.start1 = pd["start1"]
+            p.start2 = pd["start2"]
+            p.length1 = pd["length1"]
+            p.length2 = pd["length2"]
+            patches.append(p)
+    else:
+        # Legacy format (starts with @@)
+        patches = _dmp.patch_fromText(diff_text)
+
+    patched, results = _dmp.patch_apply(patches, base)
+    if not all(results):
+        failed = sum(1 for r in results if not r)
+        logger.warning(
+            f"Patch application had {failed} failed hunks out of {len(results)}"
+        )
+    return patched
+
+
+def _reconstruct_revision_content(
+    client: ClientApi, revision_id: str
+) -> Dict[str, Any]:
+    """Reconstruct full note content from a revision by walking the parent chain.
+
+    Follows parent_id links back to the first revision, then applies diffs
+    sequentially from oldest to newest to reconstruct title, body, and metadata.
+
+    Args:
+        client: Configured joppy ClientApi instance.
+        revision_id: ID of the revision to reconstruct.
+
+    Returns:
+        Dict with keys: 'title', 'body', 'metadata' (parsed metadata_diff).
+    """
+    # Collect the chain from target revision back to root
+    chain = []
+    current_id = revision_id
+
+    while current_id:
+        rev = client.get_revision(
+            current_id,
+            fields="id,parent_id,title_diff,body_diff,metadata_diff",
+        )
+        chain.append(rev)
+        current_id = getattr(rev, "parent_id", "") or ""
+
+    # Apply diffs from root (last in chain) forward to target (first in chain)
+    chain.reverse()
+
+    title = ""
+    body = ""
+    metadata: Dict[str, Any] = {}
+
+    for rev in chain:
+        title_diff = getattr(rev, "title_diff", "") or ""
+        body_diff = getattr(rev, "body_diff", "") or ""
+        metadata_diff_str = getattr(rev, "metadata_diff", "") or ""
+
+        if title_diff and title_diff != "[]":
+            title = _apply_diff(title_diff, title)
+        if body_diff and body_diff != "[]":
+            body = _apply_diff(body_diff, body)
+        if metadata_diff_str:
+            try:
+                md = json.loads(metadata_diff_str)
+                # Apply "new" fields, remove "deleted" fields
+                metadata.update(md.get("new", {}))
+                for key in md.get("deleted", []):
+                    metadata.pop(key, None)
+            except Exception:
+                pass
+
+    return {"title": title, "body": body, "metadata": metadata}
+
+
+def save_note_revision(client: ClientApi, note_id: str) -> Optional[str]:
+    """Save current note content as a Joplin revision before overwriting.
+
+    Creates a revision snapshot using Joplin's native revision system.
+    Follows Joplin's createNoteRevision_ algorithm:
+    - If prior revisions exist: reconstructs previous state, diffs sequentially,
+      sets parent_id to chain with existing revisions.
+    - If no prior revisions: diffs from empty string (first revision).
+
+    Uses client.add_revision() with corrected millisecond timestamps
+    (joppy bug: uses seconds internally -- our kwargs override via **data).
+
+    Args:
+        client: Configured joppy ClientApi instance.
+        note_id: ID of the note to snapshot.
+
+    Returns:
+        Revision ID string on success, None on failure (logs warning).
+    """
+    try:
+        note = client.get_note(
+            note_id,
+            fields="id,parent_id,title,body,is_todo,todo_completed",
+        )
+
+        title = getattr(note, "title", "") or ""
+        body = getattr(note, "body", "") or ""
+        notebook_id = getattr(note, "parent_id", "") or ""
+        is_todo = getattr(note, "is_todo", 0) or 0
+        todo_completed = getattr(note, "todo_completed", 0) or 0
+
+        # Find the latest existing revision for this note
+        prev_title = ""
+        prev_body = ""
+        parent_rev_id = ""
+
+        try:
+            all_revs = client.get_all_revisions(fields="id,item_id,created_time")
+            note_revs = [
+                r for r in all_revs if getattr(r, "item_id", "") == note_id
+            ]
+            if note_revs:
+                note_revs.sort(
+                    key=lambda r: getattr(r, "created_time", 0), reverse=True
+                )
+                latest_rev = note_revs[0]
+                parent_rev_id = latest_rev.id
+                # Reconstruct previous state from the revision chain
+                prev_content = _reconstruct_revision_content(client, parent_rev_id)
+                prev_title = prev_content["title"]
+                prev_body = prev_content["body"]
+        except Exception as e:
+            logger.debug(
+                f"Could not find parent revision for note {note_id}: {e}"
+            )
+
+        # Create diffs from previous state to current content
+        title_diff = _dmp.patch_toText(_dmp.patch_make(prev_title, title))
+        body_diff = _dmp.patch_toText(_dmp.patch_make(prev_body, body))
+
+        # Build metadata_diff: track what changed from previous metadata
+        new_metadata = {
+            "id": note_id,
+            "parent_id": notebook_id,
+            "is_todo": is_todo,
+            "todo_completed": todo_completed,
+            "title": title,
+        }
+        metadata_diff = json.dumps({"new": new_metadata, "deleted": []})
+
+        now_ms = int(time.time() * 1000)
+
+        revision_data = {
+            "item_updated_time": now_ms,
+            "item_created_time": now_ms,
+            "title_diff": title_diff,
+            "body_diff": body_diff,
+            "metadata_diff": metadata_diff,
+        }
+        if parent_rev_id:
+            revision_data["parent_id"] = parent_rev_id
+
+        rev_id = client.add_revision(
+            item_id=note_id,
+            item_type=joppy.data_types.ItemType.NOTE,
+            **revision_data,
+        )
+        logger.info(
+            f"Saved revision {rev_id} for note {note_id} "
+            f"(parent: {parent_rev_id or 'none'})"
+        )
+        return rev_id
+
+    except Exception as e:
+        logger.warning(f"Failed to save revision for note {note_id}: {e}")
+        return None

--- a/src/joplin_mcp/tools/__init__.py
+++ b/src/joplin_mcp/tools/__init__.py
@@ -1,4 +1,22 @@
 """Joplin MCP Tools - importing registers all tools with the server."""
-from joplin_mcp.tools import notes, notebooks, tags
+from joplin_mcp.tools import (
+    notes,
+    notebooks,
+    tags,
+    notes_bulk,
+    tags_bulk,
+    trash,
+    notes_revisions,
+    backup_database,
+)
 
-__all__ = ["notes", "notebooks", "tags"]
+__all__ = [
+    "notes",
+    "notebooks",
+    "tags",
+    "notes_bulk",
+    "tags_bulk",
+    "trash",
+    "notes_revisions",
+    "backup_database",
+]

--- a/src/joplin_mcp/tools/backup_database.py
+++ b/src/joplin_mcp/tools/backup_database.py
@@ -1,0 +1,161 @@
+"""Database backup tools for Joplin MCP — SQLite snapshot management."""
+import datetime
+import logging
+import platform
+import subprocess
+from pathlib import Path
+from typing import Annotated, Optional
+
+from pydantic import Field
+
+from joplin_mcp.fastmcp_server import create_tool
+
+logger = logging.getLogger(__name__)
+
+_BACKUP_RETENTION = 10
+
+
+def _get_joplin_db_path() -> Path:
+    """Return the platform-appropriate path to Joplin's SQLite database.
+
+    Raises:
+        FileNotFoundError: If the database file does not exist at the
+            expected location.
+    """
+    system = platform.system()
+    if system == "Windows":
+        base = Path.home() / "AppData" / "Roaming"
+    else:
+        # macOS and Linux both use ~/.config
+        base = Path.home() / ".config"
+
+    db_path = base / "joplin-desktop" / "database.sqlite"
+    if not db_path.exists():
+        raise FileNotFoundError(
+            f"Joplin database not found at {db_path}. "
+            "Is Joplin Desktop installed?"
+        )
+    return db_path
+
+
+_BACKUP_DIR = Path.home() / "JoplinBackup" / "default" / "mcp-backups"
+
+
+def backup_joplin_database(force: bool = False) -> Optional[str]:
+    """Create a SQLite backup of the Joplin database.
+
+    Uses sqlite3's .backup command for a safe, consistent snapshot even
+    while Joplin Desktop is running.
+
+    By default (force=False): creates auto-backup with once-per-day guard,
+    subject to automatic retention cleanup (last N kept).
+
+    With force=True: creates manual backup that is never auto-deleted,
+    requiring explicit user cleanup.
+
+    Args:
+        force: If True, create manual backup (no daily guard, no
+            auto-cleanup).
+
+    Returns:
+        Backup file path on success, None on skip or failure.
+    """
+    try:
+        db_path = _get_joplin_db_path()
+    except FileNotFoundError:
+        logger.warning("Joplin database not found — skipping backup")
+        return None
+
+    _BACKUP_DIR.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+
+    if force:
+        # Manual backup — never auto-deleted
+        backup_path = _BACKUP_DIR / f"joplin_manual_backup_{timestamp}.sqlite"
+    else:
+        # Auto backup — once-per-day guard
+        today = datetime.date.today().strftime("%Y%m%d")
+        existing = list(
+            _BACKUP_DIR.glob(f"joplin_auto_backup_{today}_*.sqlite")
+        )
+        if existing:
+            logger.info(
+                f"Daily auto-backup already exists: {existing[0].name}"
+            )
+            return str(existing[0])
+        backup_path = _BACKUP_DIR / f"joplin_auto_backup_{timestamp}.sqlite"
+
+    try:
+        result = subprocess.run(
+            ["sqlite3", str(db_path), f".backup '{backup_path}'"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            logger.warning(f"SQLite backup failed: {result.stderr}")
+            return None
+
+        logger.info(f"Database backup created: {backup_path}")
+
+        # Enforce retention on auto-backups only
+        # (manual backups are never auto-deleted)
+        if not force:
+            auto_backups = sorted(
+                _BACKUP_DIR.glob("joplin_auto_backup_*.sqlite"),
+                reverse=True,
+            )
+            for old_backup in auto_backups[_BACKUP_RETENTION:]:
+                old_backup.unlink()
+                logger.info(f"Removed old auto-backup: {old_backup.name}")
+
+        return str(backup_path)
+
+    except Exception as e:
+        logger.warning(f"Database backup failed: {e}")
+        return None
+
+
+@create_tool("backup_database", "Backup Joplin database")
+async def backup_database() -> str:
+    """Create a full SQLite backup of the Joplin database.
+
+    Creates a complete snapshot of the Joplin database using SQLite's backup
+    command, safe even while Joplin Desktop is running. Use before large
+    reorganization operations or as a manual safety checkpoint.
+
+    Backups are stored in ~/JoplinBackup/default/mcp-backups/ with timestamps.
+    Last 10 auto-backups are retained; manual backups are never auto-deleted.
+
+    Note: Bulk operations (search_and_bulk_update_execute, bulk_move_notes)
+    trigger this automatically once per day. This tool bypasses the daily
+    guard and always creates a fresh backup.
+
+    Returns:
+        str: Success message with backup path, or failure details.
+    """
+    try:
+        db_path = _get_joplin_db_path()
+    except FileNotFoundError:
+        db_path = Path("~/.config/joplin-desktop/database.sqlite")
+
+    backup_path = backup_joplin_database(force=True)
+    if backup_path:
+        size_mb = Path(backup_path).stat().st_size / (1024 * 1024)
+        return (
+            "OPERATION: BACKUP_DATABASE\n"
+            "STATUS: SUCCESS\n"
+            f"BACKUP_PATH: {backup_path}\n"
+            f"SIZE: {size_mb:.1f} MB\n"
+            f"MESSAGE: Full Joplin database backup created. Restore by "
+            f"replacing {db_path} with this file (while Joplin Desktop "
+            f"is closed)."
+        )
+    else:
+        return (
+            "OPERATION: BACKUP_DATABASE\n"
+            "STATUS: FAILED\n"
+            f"MESSAGE: Could not create database backup. Joplin database "
+            f"may not exist at {db_path}. Check server logs."
+        )

--- a/src/joplin_mcp/tools/field_helpers.py
+++ b/src/joplin_mcp/tools/field_helpers.py
@@ -1,0 +1,278 @@
+"""Field registry and search helpers for bulk operation tools.
+
+Provides:
+- JOPLIN_NOTE_FIELDS: Registry mapping field names to type converters
+- ALL_NOTE_FIELDS: Comma-separated string of all fields for API requests
+- convert_todo_completed: Timestamp converter for todo_completed values
+- _search_notes: Single entry point for searching + filtering notes
+- _parse_update_params: Separates update values from filter conditions
+- extract_note_ids_from_result: Parses note IDs from formatted output
+"""
+
+import datetime
+import re
+import time
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from joplin_mcp.fastmcp_server import (
+    COMMON_NOTE_FIELDS,
+    flexible_bool_converter,
+    process_search_results,
+    timestamp_converter,
+)
+
+
+# ---------------------------------------------------------------------------
+# todo_completed converter
+# ---------------------------------------------------------------------------
+
+
+def convert_todo_completed(
+    value: Union[bool, str, int, None],
+) -> tuple[Optional[int], Optional[str]]:
+    """Convert todo_completed input to Joplin API epoch-ms timestamp.
+
+    Accepts:
+        - True/False  (True -> current time in ms, False -> 0)
+        - Epoch milliseconds (int)
+        - ISO datetime string ('YYYY-MM-DD HH:MM' or 'YYYY-MM-DD')
+
+    Returns:
+        (api_value, warning_message) tuple.
+    """
+    if value is None:
+        return (None, None)
+
+    if isinstance(value, bool):
+        return (int(time.time() * 1000) if value else 0, None)
+
+    if isinstance(value, str):
+        value_stripped = value.strip()
+        value_lower = value_stripped.lower()
+        if value_lower in ("true", "yes", "on"):
+            return (int(time.time() * 1000), None)
+        if value_lower in ("false", "no", "off"):
+            return (0, None)
+        try:
+            dt = datetime.datetime.fromisoformat(value_stripped)
+            return (int(dt.timestamp() * 1000), None)
+        except ValueError:
+            raise ValueError(
+                f"Unrecognized todo_completed format: '{value}'. "
+                "Accepts: True/False, epoch milliseconds, or ISO datetime "
+                "'YYYY-MM-DD HH:MM' / 'YYYY-MM-DD'"
+            )
+
+    if isinstance(value, (int, float)):
+        int_value = int(value)
+        if int_value == 0:
+            return (0, None)
+        if int_value >= 1_000_000_000_000:
+            return (int_value, None)
+        return (
+            int_value,
+            f"WARNING: todo_completed={int_value} interpreted as "
+            f"{int_value}ms since epoch (1970-01-01). Did you mean True?",
+        )
+
+    raise ValueError(
+        f"Invalid todo_completed type: {type(value).__name__}. "
+        "Accepts: True/False, epoch milliseconds, or ISO datetime "
+        "'YYYY-MM-DD HH:MM' / 'YYYY-MM-DD'"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Field registry
+# ---------------------------------------------------------------------------
+
+JOPLIN_NOTE_FIELDS: Dict[str, Dict[str, Any]] = {
+    "title": {
+        "type_converter": lambda x: x,
+        "description": "Note title",
+    },
+    "body": {
+        "type_converter": lambda x: x,
+        "description": "Note content",
+    },
+    "is_todo": {
+        "type_converter": flexible_bool_converter,
+        "description": "Todo status",
+    },
+    "todo_completed": {
+        "type_converter": lambda x: convert_todo_completed(x)[0],
+        "description": "Todo completion status",
+    },
+    "todo_due": {
+        "type_converter": lambda x: timestamp_converter(x, "todo_due"),
+        "description": "Todo due date (epoch ms or ISO 8601)",
+    },
+    "parent_id": {
+        "type_converter": lambda x: x,
+        "description": "Notebook ID",
+    },
+    "author": {
+        "type_converter": lambda x: x,
+        "description": "Note author",
+    },
+    "source_url": {
+        "type_converter": lambda x: x,
+        "description": "Source URL",
+    },
+    "latitude": {
+        "type_converter": lambda x: x,
+        "description": "GPS latitude coordinate",
+    },
+    "longitude": {
+        "type_converter": lambda x: x,
+        "description": "GPS longitude coordinate",
+    },
+    "altitude": {
+        "type_converter": lambda x: x,
+        "description": "GPS altitude coordinate",
+    },
+    "markup_language": {
+        "type_converter": lambda x: x,
+        "description": "Note markup format: 1=Markdown, 2=HTML",
+    },
+    "user_created_time": {
+        "type_converter": lambda x: x,
+        "description": "Custom creation timestamp in milliseconds",
+    },
+    "user_updated_time": {
+        "type_converter": lambda x: x,
+        "description": "Custom update timestamp in milliseconds",
+    },
+}
+
+# All fields to request from the API — COMMON_NOTE_FIELDS + registry fields.
+# SQLite fetches the full row regardless, so requesting extra columns is free.
+ALL_NOTE_FIELDS = ",".join(sorted(set(
+    COMMON_NOTE_FIELDS.split(",") + list(JOPLIN_NOTE_FIELDS.keys())
+)))
+
+
+# ---------------------------------------------------------------------------
+# Search and filter
+# ---------------------------------------------------------------------------
+
+
+def _search_notes(
+    client,
+    query: str,
+    **filters: Any,
+) -> Tuple[List[Any], int]:
+    """Search Joplin notes and apply field-value filters.
+
+    Two-phase approach:
+    1. Joplin API text search (handles full-text, notebook:, tag:, title:, etc.)
+    2. Python post-filtering for field-value conditions the API can't express
+       (e.g., author="Albert", is_todo=True). All filters are AND logic.
+
+    The query string is passed to Joplin untouched — never parsed for field
+    names. All fields from the registry are always fetched so filters can
+    inspect any field without a second API call.
+
+    Args:
+        client: Joplin ClientApi instance.
+        query: Search query for Joplin. Supports Joplin search operators
+            (notebook:, tag:, title:, body:, type:, etc.) and "*" for all notes.
+        **filters: Field conditions (AND logic). Keys must be valid field names
+            from JOPLIN_NOTE_FIELDS. Example: is_todo=True, author="Albert".
+
+    Returns:
+        (matching_notes, skipped_count) tuple.
+    """
+    # Phase 1: Joplin API search
+    if query.strip() == "*":
+        results = client.get_all_notes(fields=ALL_NOTE_FIELDS)
+        notes = process_search_results(results)
+        notes.sort(
+            key=lambda x: getattr(x, "updated_time", 0), reverse=True
+        )
+    else:
+        results = client.search_all(query=query, fields=ALL_NOTE_FIELDS)
+        notes = process_search_results(results)
+
+    # Phase 2: Python field-value filtering (AND logic)
+    if not filters:
+        return notes, 0
+
+    matching = []
+    skipped = 0
+    for note in notes:
+        match = True
+        for field, expected in filters.items():
+            if expected is not None and getattr(note, field, None) != expected:
+                match = False
+                break
+        if match:
+            matching.append(note)
+        else:
+            skipped += 1
+
+    return matching, skipped
+
+
+# ---------------------------------------------------------------------------
+# Update parameter parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_update_params(**kwargs: Any) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """Separate update values from filter conditions.
+
+    Convention: parameters ending in ``_filter`` are conditions (used by
+    _search_notes for post-fetch filtering). All other parameters matching
+    JOPLIN_NOTE_FIELDS keys are update values. Unknown keys are ignored.
+
+    Args:
+        **kwargs: All tool parameters (field values, filters, and anything else).
+
+    Returns:
+        (updates, filters) tuple.
+        - updates: {field_name: new_value} for fields to modify.
+        - filters: {field_name: required_value} for _search_notes filtering.
+    """
+    updates: Dict[str, Any] = {}
+    filters: Dict[str, Any] = {}
+
+    for key, value in kwargs.items():
+        if value is None:
+            continue
+        if key.endswith("_filter"):
+            field = key[:-7]  # strip "_filter"
+            if field in JOPLIN_NOTE_FIELDS:
+                filters[field] = value
+        elif key in JOPLIN_NOTE_FIELDS:
+            updates[key] = value
+
+    return updates, filters
+
+
+# ---------------------------------------------------------------------------
+# Utility
+# ---------------------------------------------------------------------------
+
+
+def extract_note_ids_from_result(formatted_result: str, limit: int) -> List[str]:
+    """Extract note IDs from formatted search results.
+
+    Parses output looking for lines matching ``note_id: <32-hex-chars>``.
+
+    Args:
+        formatted_result: Formatted string output from find_notes/preview.
+        limit: Maximum number of note IDs to extract.
+
+    Returns:
+        List of note IDs (up to *limit*).
+    """
+    note_ids: List[str] = []
+    pattern = r"^\s*note_id:\s*([a-f0-9]{32})"
+
+    for line in formatted_result.split("\n"):
+        match = re.match(pattern, line)
+        if match and len(note_ids) < limit:
+            note_ids.append(match.group(1))
+
+    return note_ids

--- a/src/joplin_mcp/tools/notebooks.py
+++ b/src/joplin_mcp/tools/notebooks.py
@@ -89,14 +89,13 @@ async def update_notebook(
 async def delete_notebook(
     notebook_id: Annotated[JoplinIdType, Field(description="Notebook ID to delete")],
 ) -> str:
-    """Delete a notebook from Joplin.
+    """Delete a notebook from Joplin (moves to trash).
 
-    Permanently removes a notebook from Joplin. This action cannot be undone.
+    Moves a notebook and its contained notes to Joplin's trash. Recoverable
+    via list_trash and restore_from_trash, or Joplin Desktop's trash interface.
 
     Returns:
-        str: Success message confirming the notebook was deleted.
-
-    Warning: This action is permanent and cannot be undone. All notes in the notebook will also be deleted.
+        str: Success message confirming the notebook was moved to trash.
     """
     client = get_joplin_client()
     client.delete_notebook(notebook_id)

--- a/src/joplin_mcp/tools/notes.py
+++ b/src/joplin_mcp/tools/notes.py
@@ -77,6 +77,8 @@ from joplin_mcp.fastmcp_server import (
     timestamp_converter,
     validate_joplin_id,
 )
+from joplin_mcp.revision_utils import save_note_revision
+from joplin_mcp.tools.field_helpers import convert_todo_completed
 from joplin_mcp.formatting import (
     build_pagination_header,
     format_find_in_note_summary,
@@ -734,7 +736,8 @@ async def update_note(
         OptionalBoolType, Field(description="Convert to/from todo (optional)")
     ] = None,
     todo_completed: Annotated[
-        OptionalBoolType, Field(description="Mark todo completed (optional)")
+        Optional[Union[bool, str, int]],
+        Field(description="Mark todo completed: True/False (uses current time), epoch ms, or ISO datetime (optional)")
     ] = None,
     todo_due: Annotated[
         Optional[Union[int, str]],
@@ -759,9 +762,9 @@ async def update_note(
     # Runtime validation for Jan AI compatibility while preserving functionality
     note_id = validate_joplin_id(note_id)
     is_todo = flexible_bool_converter(is_todo)
-    todo_completed = flexible_bool_converter(todo_completed)
 
     update_data = {}
+    warning_msg = None
     if title is not None:
         update_data["title"] = title
     if body is not None:
@@ -769,7 +772,12 @@ async def update_note(
     if is_todo is not None:
         update_data["is_todo"] = 1 if is_todo else 0
     if todo_completed is not None:
-        update_data["todo_completed"] = 1 if todo_completed else 0
+        completed_value, warning_msg = convert_todo_completed(todo_completed)
+        if completed_value is not None:
+            update_data["todo_completed"] = completed_value
+            # Auto-set is_todo when marking complete
+            if completed_value > 0 and "is_todo" not in update_data:
+                update_data["is_todo"] = 1
     if todo_due is not None:
         update_data["todo_due"] = timestamp_converter(todo_due, "todo_due") or 0
 
@@ -777,10 +785,21 @@ async def update_note(
         raise ValueError("At least one field must be provided for update")
 
     client = get_joplin_client()
+
+    # Auto-backup revision before overwriting title or body
+    if "title" in update_data or "body" in update_data:
+        try:
+            save_note_revision(client, note_id)
+        except Exception:
+            pass  # Best-effort backup — don't block the update
+
     client.modify_note(note_id, **update_data)
     _clear_note_cache()
 
-    return format_update_success(ItemType.note, note_id)
+    result = format_update_success(ItemType.note, note_id)
+    if warning_msg:
+        result += f"\nWARNING: {warning_msg}"
+    return result
 
 
 @create_tool("edit_note", "Edit note")
@@ -856,6 +875,12 @@ async def edit_note(
     note = client.get_note(note_id, fields=COMMON_NOTE_FIELDS)
     body = getattr(note, "body", "") or ""
 
+    # Auto-backup revision before modifying body
+    try:
+        save_note_revision(client, note_id)
+    except Exception:
+        pass  # Best-effort backup — don't block the edit
+
     if old_string is not None:
         # Replacement / deletion mode
         count = body.count(old_string)
@@ -908,14 +933,13 @@ async def edit_note(
 async def delete_note(
     note_id: Annotated[JoplinIdType, Field(description="Note ID to delete")],
 ) -> str:
-    """Delete a note from Joplin.
+    """Delete a note from Joplin (moves to trash).
 
-    Permanently removes a note from Joplin. This action cannot be undone.
+    Moves a note to Joplin's trash. The note can be recovered using list_trash
+    and restore_from_trash, or via Joplin Desktop's trash interface.
 
     Returns:
-        str: Success message confirming the note was deleted.
-
-    Warning: This action is permanent and cannot be undone.
+        str: Success message confirming the note was moved to trash.
     """
     # Runtime validation for Jan AI compatibility while preserving functionality
     note_id = validate_joplin_id(note_id)

--- a/src/joplin_mcp/tools/notes_bulk.py
+++ b/src/joplin_mcp/tools/notes_bulk.py
@@ -1,0 +1,677 @@
+"""Bulk note operation tools for Joplin MCP."""
+
+from typing import Annotated, List, Optional, Union
+
+from pydantic import Field
+
+from joplin_mcp.fastmcp_server import (
+    ItemType,
+    JoplinIdType,
+    OptionalBoolType,
+    apply_pagination,
+    create_tool,
+    flexible_bool_converter,
+    format_search_results_with_pagination,
+    format_update_success,
+    get_joplin_client,
+    validate_joplin_id,
+)
+from joplin_mcp.notebook_utils import get_notebook_id_by_name
+from joplin_mcp.revision_utils import save_note_revision
+from joplin_mcp.tools.backup_database import backup_joplin_database
+from joplin_mcp.tools.field_helpers import (
+    JOPLIN_NOTE_FIELDS,
+    _search_notes,
+    _parse_update_params,
+    extract_note_ids_from_result,
+)
+
+
+# === BULK NOTE TOOLS ===
+
+
+@create_tool("move_note", "Move note")
+async def move_note(
+    note_id: Annotated[JoplinIdType, Field(description="Note ID to move")],
+    target_notebook: Annotated[
+        Optional[str],
+        Field(description="Target notebook name to move note to"),
+    ] = None,
+    target_notebook_id: Annotated[
+        Optional[str],
+        Field(description="Target notebook ID (alternative to notebook name)"),
+    ] = None,
+) -> str:
+    """Move a single note to a different notebook.
+
+    Changes the parent notebook of a note by updating its parent_id field.
+    Specify either target_notebook (name) OR target_notebook_id (ID) - one is required.
+
+    Returns:
+        str: Success message confirming the note was moved.
+
+    Examples:
+        - move_note("note123", target_notebook="Archive") - Move note to Archive notebook
+        - move_note("note123", target_notebook_id="abc123def456") - Move using notebook ID
+    """
+    note_id = validate_joplin_id(note_id)
+
+    if target_notebook is None and target_notebook_id is None:
+        raise ValueError(
+            "Must specify either target_notebook (name) or target_notebook_id (ID)"
+        )
+    if target_notebook is not None and target_notebook_id is not None:
+        raise ValueError(
+            "Cannot specify both target_notebook and target_notebook_id. Use one or the other."
+        )
+
+    if target_notebook is not None:
+        target_notebook_id = get_notebook_id_by_name(target_notebook)
+
+    target_notebook_id = validate_joplin_id(target_notebook_id)
+
+    client = get_joplin_client()
+    try:
+        client.modify_note(note_id, parent_id=target_notebook_id)
+        result = format_update_success(ItemType.note, note_id)
+        return f"{result}\nMOVED_TO_NOTEBOOK_ID: {target_notebook_id}"
+    except Exception as e:
+        raise RuntimeError(f"Failed to move note: {e}")
+
+
+@create_tool("bulk_move_notes", "Bulk move notes")
+async def bulk_move_notes(
+    note_ids: Annotated[
+        List[str], Field(description="List of note IDs to move")
+    ],
+    target_notebook: Annotated[
+        Optional[str],
+        Field(description="Target notebook name to move notes to"),
+    ] = None,
+    target_notebook_id: Annotated[
+        Optional[str],
+        Field(description="Target notebook ID (alternative to notebook name)"),
+    ] = None,
+    backup: Annotated[
+        Optional[str],
+        Field(description="Database backup before operation: 'daily' (default, once per day), 'force' (always), 'suppress' (skip). WARNING: Never set to 'suppress' unless the user explicitly requests it."),
+    ] = "daily",
+) -> str:
+    """Move multiple notes to a target notebook in a single operation.
+
+    Efficiently moves multiple notes between notebooks by updating their parent_id field.
+    Specify either target_notebook (name) OR target_notebook_id (ID) - one is required.
+
+    Returns:
+        str: Summary with success/failure counts.
+
+    Examples:
+        - bulk_move_notes(["note1", "note2", "note3"], target_notebook="Archive")
+        - bulk_move_notes(["note1", "note2"], target_notebook_id="abc123def456")
+    """
+    if target_notebook is None and target_notebook_id is None:
+        raise ValueError(
+            "Must specify either target_notebook (name) or target_notebook_id (ID)"
+        )
+    if target_notebook is not None and target_notebook_id is not None:
+        raise ValueError(
+            "Cannot specify both target_notebook and target_notebook_id. Use one or the other."
+        )
+
+    if target_notebook is not None:
+        target_notebook_id = get_notebook_id_by_name(target_notebook)
+
+    target_notebook_id = validate_joplin_id(target_notebook_id)
+
+    validated_note_ids = [validate_joplin_id(nid) for nid in note_ids]
+    if not validated_note_ids:
+        raise ValueError("At least one note ID must be provided")
+
+    client = get_joplin_client()
+
+    # Backup database before bulk operation
+    if backup != "suppress":
+        backup_joplin_database(force=(backup == "force"))
+
+    success_count = 0
+    failed_moves: List[str] = []
+
+    for nid in validated_note_ids:
+        try:
+            client.modify_note(nid, parent_id=target_notebook_id)
+            success_count += 1
+        except Exception as e:
+            failed_moves.append(f"Note {nid}: {e}")
+
+    result_lines = [
+        "operation: bulk_move_notes",
+        f"status: {'partial_success' if failed_moves else 'success'}",
+        f"total_notes: {len(validated_note_ids)}",
+        f"moved_successfully: {success_count}",
+        f"target_notebook_id: {target_notebook_id}",
+    ]
+
+    if failed_moves:
+        result_lines.append(f"failed_moves: {len(failed_moves)}")
+        result_lines.extend([f"  - {error}" for error in failed_moves])
+
+    return "\n".join(result_lines)
+
+
+@create_tool(
+    "search_and_bulk_update_preview", "Search and bulk update preview"
+)
+async def search_and_bulk_update_preview(
+    query: Annotated[
+        str, Field(description="Search text or '*' for all notes")
+    ],
+    preview_limit: Annotated[
+        int,
+        Field(description="Number of notes to show in preview (default: 5)"),
+    ] = 5,
+    inspect_count: Annotated[
+        int,
+        Field(
+            description="Number of notes to show full content for (default: 2)"
+        ),
+    ] = 2,
+    # Update parameters
+    title: Annotated[
+        Optional[str], Field(description="New title to simulate (optional)")
+    ] = None,
+    body: Annotated[
+        Optional[str],
+        Field(description="New content to simulate (optional)"),
+    ] = None,
+    is_todo: Annotated[
+        OptionalBoolType,
+        Field(description="Convert to/from todo to simulate (optional)"),
+    ] = None,
+    todo_completed: Annotated[
+        Optional[Union[bool, str, int]],
+        Field(
+            description="Mark todo completed to simulate. Accepts: True/False (uses current time), epoch milliseconds, or ISO datetime 'YYYY-MM-DD HH:MM' / 'YYYY-MM-DD' (optional)"
+        ),
+    ] = None,
+    parent_id: Annotated[
+        Optional[str],
+        Field(
+            description="Move notes to different notebook to simulate (notebook ID, optional)"
+        ),
+    ] = None,
+    parent_notebook: Annotated[
+        Optional[str],
+        Field(
+            description="Move notes to different notebook to simulate (notebook name, optional)"
+        ),
+    ] = None,
+    author: Annotated[
+        Optional[str],
+        Field(description="Note author to simulate (optional)"),
+    ] = None,
+    source_url: Annotated[
+        Optional[str],
+        Field(description="Source URL to simulate (optional)"),
+    ] = None,
+    latitude: Annotated[
+        Optional[float],
+        Field(description="GPS latitude coordinate to simulate (optional)"),
+    ] = None,
+    longitude: Annotated[
+        Optional[float],
+        Field(description="GPS longitude coordinate to simulate (optional)"),
+    ] = None,
+    altitude: Annotated[
+        Optional[float],
+        Field(description="GPS altitude coordinate to simulate (optional)"),
+    ] = None,
+    markup_language: Annotated[
+        Optional[int],
+        Field(
+            description="Note markup format: 1=Markdown, 2=HTML to simulate (optional)"
+        ),
+    ] = None,
+    user_created_time: Annotated[
+        Optional[int],
+        Field(
+            description="Custom creation timestamp in milliseconds to simulate (optional)"
+        ),
+    ] = None,
+    user_updated_time: Annotated[
+        Optional[int],
+        Field(
+            description="Custom update timestamp in milliseconds to simulate (optional)"
+        ),
+    ] = None,
+    # Filter parameters for conditional updates
+    is_todo_filter: Annotated[
+        OptionalBoolType,
+        Field(
+            description="Only update if current is_todo matches this (optional)"
+        ),
+    ] = None,
+    todo_completed_filter: Annotated[
+        OptionalBoolType,
+        Field(
+            description="Only update if current todo_completed matches this (optional)"
+        ),
+    ] = None,
+    title_filter: Annotated[
+        Optional[str],
+        Field(
+            description="Only update if current title matches this (optional)"
+        ),
+    ] = None,
+    body_filter: Annotated[
+        Optional[str],
+        Field(
+            description="Only update if current body matches this (optional)"
+        ),
+    ] = None,
+    parent_id_filter: Annotated[
+        Optional[str],
+        Field(
+            description="Only update if current parent_id matches this (optional)"
+        ),
+    ] = None,
+    author_filter: Annotated[
+        Optional[str],
+        Field(
+            description="Only update if current author matches this (optional)"
+        ),
+    ] = None,
+    source_url_filter: Annotated[
+        Optional[str],
+        Field(
+            description="Only update if current source_url matches this (optional)"
+        ),
+    ] = None,
+    latitude_filter: Annotated[
+        Optional[float],
+        Field(
+            description="Only update if current latitude matches this (optional)"
+        ),
+    ] = None,
+    longitude_filter: Annotated[
+        Optional[float],
+        Field(
+            description="Only update if current longitude matches this (optional)"
+        ),
+    ] = None,
+    altitude_filter: Annotated[
+        Optional[float],
+        Field(
+            description="Only update if current altitude matches this (optional)"
+        ),
+    ] = None,
+    markup_language_filter: Annotated[
+        Optional[int],
+        Field(
+            description="Only update if current markup_language matches this (optional)"
+        ),
+    ] = None,
+    user_created_time_filter: Annotated[
+        Optional[int],
+        Field(
+            description="Only update if current user_created_time matches this (optional)"
+        ),
+    ] = None,
+    user_updated_time_filter: Annotated[
+        Optional[int],
+        Field(
+            description="Only update if current user_updated_time matches this (optional)"
+        ),
+    ] = None,
+) -> str:
+    """Preview search results for bulk update operations.
+
+    Shows three levels of information:
+    1. Total count of matching notes with filter statistics.
+    2. Preview of first N notes with metadata (titles, IDs, dates).
+    3. Full content inspection of first few notes for verification.
+
+    This function helps verify what notes would be affected before executing
+    bulk updates.  Always call this before search_and_bulk_update_execute.
+
+    Returns:
+        str: Complete preview with count, metadata, and content samples.
+
+    Examples:
+        - search_and_bulk_update_preview("project") - Preview notes containing "project"
+        - search_and_bulk_update_preview("*", is_todo=True, preview_limit=10)
+    """
+    # Handle parent_notebook -> parent_id conversion
+    if parent_notebook is not None and parent_id is not None:
+        raise ValueError(
+            "Cannot specify both parent_id and parent_notebook. Use one or the other."
+        )
+    if parent_notebook is not None:
+        parent_id = get_notebook_id_by_name(parent_notebook)
+
+    updates, filters = _parse_update_params(
+        title=title, body=body, is_todo=is_todo,
+        todo_completed=todo_completed, parent_id=parent_id,
+        author=author, source_url=source_url,
+        latitude=latitude, longitude=longitude, altitude=altitude,
+        markup_language=markup_language,
+        user_created_time=user_created_time, user_updated_time=user_updated_time,
+        is_todo_filter=is_todo_filter, todo_completed_filter=todo_completed_filter,
+        title_filter=title_filter, body_filter=body_filter,
+        parent_id_filter=parent_id_filter, author_filter=author_filter,
+        source_url_filter=source_url_filter,
+        latitude_filter=latitude_filter, longitude_filter=longitude_filter,
+        altitude_filter=altitude_filter,
+        markup_language_filter=markup_language_filter,
+        user_created_time_filter=user_created_time_filter,
+        user_updated_time_filter=user_updated_time_filter,
+    )
+
+    client = get_joplin_client()
+    try:
+        all_notes, skipped_by_filter = _search_notes(client, query, **filters)
+        total_found = len(all_notes) + skipped_by_filter
+        paginated_notes, _ = apply_pagination(all_notes, preview_limit, 0)
+        if not paginated_notes:
+            return f"No notes found matching query: {query}"
+
+        search_description = "all notes" if query.strip() == "*" else f"text search: {query}"
+        preview_result = format_search_results_with_pagination(
+            search_description, paginated_notes, len(all_notes),
+            preview_limit, 0, "search_results", original_query=query,
+        )
+
+        filter_info = ""
+        if filters:
+            filter_info = (
+                f"\n\n=== FILTER RESULTS ===\n"
+                f"Notes matching search: {total_found}\n"
+                f"Notes passing filters: {len(all_notes)}\n"
+                f"Notes skipped by filters: {skipped_by_filter}\n"
+                f"Active filters: {', '.join(f'{k}={v}' for k, v in filters.items())}\n"
+            )
+
+        note_ids = extract_note_ids_from_result(preview_result, inspect_count)
+        content_parts = []
+        for nid in note_ids:
+            try:
+                note = client.get_note(nid, fields="id,title,body")
+                body_text = getattr(note, "body", "")
+                preview = body_text[:500] + "..." if len(body_text) > 500 else body_text
+                content_parts.append(f"--- NOTE {nid} ({note.title}) ---\n{preview}\n")
+            except Exception as e:
+                content_parts.append(f"--- NOTE {nid} ERROR ---\n{e}\n")
+    except Exception as e:
+        return f"Error during preview: {e}"
+
+    result_parts = [preview_result]
+    if filter_info:
+        result_parts.append(filter_info)
+    if content_parts:
+        result_parts.append(f"\n=== FULL CONTENT INSPECTION ===\nShowing full content for first {len(note_ids)} notes for verification:\n")
+        result_parts.extend(content_parts)
+    return "\n".join(result_parts)
+
+
+@create_tool(
+    "search_and_bulk_update_execute", "Search and bulk update execute"
+)
+async def search_and_bulk_update_execute(
+    query: Annotated[
+        str,
+        Field(
+            description="Search text or '*' for all notes (must match preview)"
+        ),
+    ],
+    expected_count: Annotated[
+        int, Field(description="Expected number of notes from preview")
+    ],
+    first_title: Annotated[
+        str, Field(description="Title of first note from preview")
+    ],
+    # Update parameters
+    title: Annotated[
+        Optional[str], Field(description="New title (optional)")
+    ] = None,
+    body: Annotated[
+        Optional[str], Field(description="New content (optional)")
+    ] = None,
+    is_todo: Annotated[
+        OptionalBoolType,
+        Field(description="Convert to/from todo (optional)"),
+    ] = None,
+    todo_completed: Annotated[
+        Optional[Union[bool, str, int]],
+        Field(
+            description="Mark todo completed. Accepts: True/False (uses current time), epoch milliseconds, or ISO datetime 'YYYY-MM-DD HH:MM' / 'YYYY-MM-DD' (optional)"
+        ),
+    ] = None,
+    parent_id: Annotated[
+        Optional[str],
+        Field(
+            description="Move notes to different notebook (notebook ID, optional)"
+        ),
+    ] = None,
+    parent_notebook: Annotated[
+        Optional[str],
+        Field(
+            description="Move notes to different notebook (notebook name, optional)"
+        ),
+    ] = None,
+    author: Annotated[
+        Optional[str], Field(description="Note author (optional)")
+    ] = None,
+    source_url: Annotated[
+        Optional[str],
+        Field(description="Source URL for web clips (optional)"),
+    ] = None,
+    latitude: Annotated[
+        Optional[float],
+        Field(description="GPS latitude coordinate (optional)"),
+    ] = None,
+    longitude: Annotated[
+        Optional[float],
+        Field(description="GPS longitude coordinate (optional)"),
+    ] = None,
+    altitude: Annotated[
+        Optional[float],
+        Field(description="GPS altitude coordinate (optional)"),
+    ] = None,
+    markup_language: Annotated[
+        Optional[int],
+        Field(
+            description="Note markup format: 1=Markdown, 2=HTML (optional)"
+        ),
+    ] = None,
+    user_created_time: Annotated[
+        Optional[int],
+        Field(
+            description="Custom creation timestamp in milliseconds (optional)"
+        ),
+    ] = None,
+    user_updated_time: Annotated[
+        Optional[int],
+        Field(
+            description="Custom update timestamp in milliseconds (optional)"
+        ),
+    ] = None,
+    # Filter parameters
+    is_todo_filter: Annotated[
+        OptionalBoolType,
+        Field(
+            description="Only update if current is_todo matches this (optional)"
+        ),
+    ] = None,
+    todo_completed_filter: Annotated[
+        OptionalBoolType,
+        Field(
+            description="Only update if current todo_completed matches this (optional)"
+        ),
+    ] = None,
+    title_filter: Annotated[
+        Optional[str],
+        Field(
+            description="Only update if current title matches this (optional)"
+        ),
+    ] = None,
+    body_filter: Annotated[
+        Optional[str],
+        Field(
+            description="Only update if current body matches this (optional)"
+        ),
+    ] = None,
+    parent_id_filter: Annotated[
+        Optional[str],
+        Field(
+            description="Only update if current parent_id matches this (optional)"
+        ),
+    ] = None,
+    author_filter: Annotated[
+        Optional[str],
+        Field(
+            description="Only update if current author matches this (optional)"
+        ),
+    ] = None,
+    source_url_filter: Annotated[
+        Optional[str],
+        Field(
+            description="Only update if current source_url matches this (optional)"
+        ),
+    ] = None,
+    latitude_filter: Annotated[
+        Optional[float],
+        Field(
+            description="Only update if current latitude matches this (optional)"
+        ),
+    ] = None,
+    longitude_filter: Annotated[
+        Optional[float],
+        Field(
+            description="Only update if current longitude matches this (optional)"
+        ),
+    ] = None,
+    altitude_filter: Annotated[
+        Optional[float],
+        Field(
+            description="Only update if current altitude matches this (optional)"
+        ),
+    ] = None,
+    markup_language_filter: Annotated[
+        Optional[int],
+        Field(
+            description="Only update if current markup_language matches this (optional)"
+        ),
+    ] = None,
+    user_created_time_filter: Annotated[
+        Optional[int],
+        Field(
+            description="Only update if current user_created_time matches this (optional)"
+        ),
+    ] = None,
+    user_updated_time_filter: Annotated[
+        Optional[int],
+        Field(
+            description="Only update if current user_updated_time matches this (optional)"
+        ),
+    ] = None,
+    backup: Annotated[
+        Optional[str],
+        Field(description="Database backup before operation: 'daily' (default, once per day), 'force' (always), 'suppress' (skip). WARNING: Never set to 'suppress' unless the user explicitly requests it."),
+    ] = "daily",
+) -> str:
+    """Execute bulk update operation on notes matching search criteria.
+
+    Performs bulk updates on all notes matching the search query after safety
+    verification.  The query and expected results must match what was shown in
+    the preview (search_and_bulk_update_preview).
+
+    Returns:
+        str: Detailed results including success/failure/skipped counts.
+
+    Examples:
+        - search_and_bulk_update_execute("project", 15, "Project Meeting", parent_id="archive_id")
+        - search_and_bulk_update_execute("*", 200, "Daily Notes", is_todo=True)
+    """
+    # Runtime validation
+    is_todo = flexible_bool_converter(is_todo)
+    is_todo_filter = flexible_bool_converter(is_todo_filter)
+    todo_completed_filter = flexible_bool_converter(todo_completed_filter)
+
+    if parent_notebook is not None and parent_id is not None:
+        raise ValueError(
+            "Cannot specify both parent_id and parent_notebook. Use one or the other."
+        )
+    if parent_notebook is not None:
+        parent_id = get_notebook_id_by_name(parent_notebook)
+
+    updates, filters = _parse_update_params(
+        title=title, body=body, is_todo=is_todo,
+        todo_completed=todo_completed, parent_id=parent_id,
+        author=author, source_url=source_url,
+        latitude=latitude, longitude=longitude, altitude=altitude,
+        markup_language=markup_language,
+        user_created_time=user_created_time, user_updated_time=user_updated_time,
+        is_todo_filter=is_todo_filter, todo_completed_filter=todo_completed_filter,
+        title_filter=title_filter, body_filter=body_filter,
+        parent_id_filter=parent_id_filter, author_filter=author_filter,
+        source_url_filter=source_url_filter,
+        latitude_filter=latitude_filter, longitude_filter=longitude_filter,
+        altitude_filter=altitude_filter,
+        markup_language_filter=markup_language_filter,
+        user_created_time_filter=user_created_time_filter,
+        user_updated_time_filter=user_updated_time_filter,
+    )
+
+    if not updates:
+        raise ValueError("At least one update field must be provided")
+
+    if backup != "suppress":
+        backup_joplin_database(force=(backup == "force"))
+
+    client = get_joplin_client()
+    matching_notes, skipped_by_filter = _search_notes(client, query, **filters)
+
+    if len(matching_notes) != expected_count:
+        raise ValueError(
+            f"Results changed: expected {expected_count}, found {len(matching_notes)}"
+        )
+    if matching_notes and getattr(matching_notes[0], "title", "") != first_title:
+        actual = getattr(matching_notes[0], "title", "Unknown")
+        raise ValueError(f"First note changed: expected '{first_title}', found '{actual}'")
+
+    # Build ONE update payload, apply to ALL matching notes
+    update_payload = {}
+    for field, value in updates.items():
+        converter = JOPLIN_NOTE_FIELDS[field]["type_converter"]
+        update_payload[field] = converter(value)
+
+    success_count = 0
+    failed_updates = []
+
+    for note in matching_notes:
+        note_id = getattr(note, "id")
+        try:
+            if "body" in update_payload or "title" in update_payload:
+                save_note_revision(client, note_id)
+            client.modify_note(note_id, **update_payload)
+            success_count += 1
+        except Exception as e:
+            note_title = getattr(note, "title", "Unknown")
+            failed_updates.append(f"Note {note_id} ({note_title}): {e}")
+
+    update_summary = ", ".join(f"{k}: {v}" for k, v in updates.items())
+    filter_summary = ", ".join(f"{k}={v}" for k, v in filters.items()) if filters else "none"
+
+    result_lines = [
+        "operation: search_and_bulk_update_execute",
+        f"status: {'partial_success' if failed_updates else 'success'}",
+        f"search_query: {query}",
+        f"total_matching: {len(matching_notes)}",
+        f"skipped_by_filter: {skipped_by_filter}",
+        f"updated_successfully: {success_count}",
+        f"updates_applied: {update_summary}",
+        f"filters_used: {filter_summary}",
+    ]
+    if failed_updates:
+        result_lines.append(f"failed_updates: {len(failed_updates)}")
+        result_lines.extend([f"  - {error}" for error in failed_updates])
+    return "\n".join(result_lines)

--- a/src/joplin_mcp/tools/notes_revisions.py
+++ b/src/joplin_mcp/tools/notes_revisions.py
@@ -1,0 +1,251 @@
+"""Revision history tools for Joplin MCP -- browse, restore, and snapshot note revisions."""
+
+import json
+import logging
+from typing import Annotated, Optional
+
+from pydantic import Field
+
+from joplin_mcp.content_utils import format_timestamp
+from joplin_mcp.fastmcp_server import (
+    JoplinIdType,
+    create_tool,
+    format_creation_success,
+    get_joplin_client,
+    get_notebook_id_by_name,
+    validate_joplin_id,
+)
+from joplin_mcp.formatting import ItemType
+from joplin_mcp.revision_utils import (
+    _apply_diff,
+    _reconstruct_revision_content,
+    save_note_revision,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# === REVISION HISTORY TOOLS ===
+
+
+@create_tool("get_note_history", "Get note revision history")
+async def get_note_history(
+    note_id: Annotated[
+        JoplinIdType, Field(description="Note ID to get revision history for")
+    ],
+) -> str:
+    """List all saved revisions for a specific note.
+
+    Shows the revision history with timestamps, enabling recovery of previous
+    versions via restore_note_revision or Joplin Desktop's "Note History" UI.
+    Revisions are created automatically by Joplin Desktop (every 10 minutes)
+    and by MCP's auto-backup before title/body overwrites.
+
+    Returns:
+        str: List of revisions with timestamps, titles, and chain information.
+    """
+    note_id = validate_joplin_id(note_id)
+    client = get_joplin_client()
+
+    # Get all revisions and filter to this note
+    all_revs = client.get_all_revisions(
+        fields="id,item_id,item_type,item_updated_time,parent_id,"
+        "created_time,title_diff,metadata_diff"
+    )
+    note_revs = [r for r in all_revs if getattr(r, "item_id", "") == note_id]
+
+    if not note_revs:
+        return (
+            f"NOTE_ID: {note_id}\n"
+            f"REVISIONS: 0\n"
+            f"STATUS: No revision history found for this note"
+        )
+
+    # Sort by created_time, most recent first
+    note_revs.sort(key=lambda r: getattr(r, "created_time", 0), reverse=True)
+
+    # Try to get current note title for context
+    try:
+        note = client.get_note(note_id, fields="id,title")
+        current_title = getattr(note, "title", "Unknown")
+    except Exception:
+        current_title = "Unknown (note may be deleted)"
+
+    lines = [
+        f"NOTE_ID: {note_id}",
+        f"CURRENT_TITLE: {current_title}",
+        f"REVISIONS: {len(note_revs)}",
+        "",
+    ]
+
+    for i, rev in enumerate(note_revs, 1):
+        rev_time = format_timestamp(getattr(rev, "created_time", None))
+        parent_id = getattr(rev, "parent_id", "") or ""
+
+        # Extract title from title_diff by applying patch to empty string
+        rev_title = None
+        title_diff = getattr(rev, "title_diff", "") or ""
+        if title_diff and title_diff != "[]":
+            try:
+                patched = _apply_diff(title_diff, "")
+                if patched:
+                    rev_title = patched
+            except Exception:
+                pass
+
+        # Fall back to metadata_diff for title
+        if not rev_title:
+            metadata_diff = getattr(rev, "metadata_diff", "") or ""
+            if metadata_diff:
+                try:
+                    md = json.loads(metadata_diff)
+                    rev_title = md.get("new", {}).get("title", None)
+                except Exception:
+                    pass
+
+        lines.append(f"REVISION_{i}:")
+        lines.append(f"  revision_id: {rev.id}")
+        lines.append(f"  created: {rev_time}")
+        if rev_title:
+            lines.append(f"  title: {rev_title}")
+        lines.append(
+            f"  has_parent: {'yes' if parent_id else 'no (first revision)'}"
+        )
+        if parent_id:
+            lines.append(f"  parent_id: {parent_id}")
+
+    return "\n".join(lines)
+
+
+@create_tool("restore_note_revision", "Restore a note from revision history")
+async def restore_note_revision(
+    revision_id: Annotated[
+        str,
+        Field(
+            description="Revision ID to restore (from get_note_history)"
+        ),
+    ],
+    target_notebook: Annotated[
+        Optional[str],
+        Field(
+            description=(
+                "Notebook name for restored note (default: original notebook, "
+                "or 'Restored Notes' if unavailable)"
+            )
+        ),
+    ] = None,
+) -> str:
+    """Restore a previous version of a note from its revision history.
+
+    Reconstructs the note content from revision diffs and creates a NEW note
+    with the restored content (same behaviour as Joplin Desktop's restore).
+    Does not overwrite the current version of the note.
+
+    Use get_note_history first to find the revision_id to restore.
+
+    Returns:
+        str: Success message with the restored note's ID and location.
+    """
+    client = get_joplin_client()
+
+    # Reconstruct content from revision chain
+    try:
+        content = _reconstruct_revision_content(client, revision_id)
+    except Exception as e:
+        raise ValueError(f"Failed to reconstruct revision: {e}")
+
+    title = content["title"] or "Untitled (restored)"
+    body = content["body"] or ""
+    metadata = content["metadata"]
+
+    # Determine target notebook
+    target_notebook_id = None
+    if target_notebook:
+        target_notebook_id = get_notebook_id_by_name(target_notebook)
+    elif metadata.get("parent_id"):
+        # Try original notebook
+        try:
+            import datetime as dt_module
+
+            nb = client.get_notebook(
+                metadata["parent_id"], fields="id,title,deleted_time"
+            )
+            deleted = getattr(nb, "deleted_time", None)
+            if deleted and deleted != dt_module.datetime(1970, 1, 1, 0, 0):
+                target_notebook_id = None  # Original notebook is trashed
+            else:
+                target_notebook_id = metadata["parent_id"]
+        except Exception:
+            target_notebook_id = None
+
+    # Fall back to "Restored Notes" notebook (create if needed)
+    if not target_notebook_id:
+        try:
+            target_notebook_id = get_notebook_id_by_name("Restored Notes")
+        except ValueError:
+            nb = client.add_notebook(title="Restored Notes")
+            target_notebook_id = str(nb)
+
+    # Create the restored note
+    note_id = str(
+        client.add_note(title=title, body=body, parent_id=target_notebook_id)
+    )
+
+    # Get target notebook name for display
+    try:
+        nb = client.get_notebook(target_notebook_id, fields="id,title")
+        nb_name = getattr(nb, "title", target_notebook_id)
+    except Exception:
+        nb_name = target_notebook_id
+
+    return (
+        f"OPERATION: RESTORE_NOTE_REVISION\n"
+        f"STATUS: SUCCESS\n"
+        f"RESTORED_NOTE_ID: {note_id}\n"
+        f"TITLE: {title}\n"
+        f"NOTEBOOK: {nb_name}\n"
+        f"SOURCE_REVISION: {revision_id}\n"
+        f'MESSAGE: Note restored from revision history as a new note in "{nb_name}"'
+    )
+
+
+@create_tool("manually_backup_note", "Create manual revision backup")
+async def manually_backup_note(
+    note_id: Annotated[
+        JoplinIdType, Field(description="Note ID to backup")
+    ],
+) -> str:
+    """Create a manual revision snapshot of a note's current content.
+
+    Saves the note's current title and body as a Joplin revision, enabling
+    recovery via get_note_history + restore_note_revision or Joplin Desktop's
+    "Note History" UI. Use before risky manual edits or bulk operations.
+
+    Note: Revisions are also created automatically before title/body overwrites
+    by update_note and search_and_bulk_update_execute.
+
+    Returns:
+        str: Success message with the revision ID.
+    """
+    note_id = validate_joplin_id(note_id)
+    client = get_joplin_client()
+
+    rev_id = save_note_revision(client, note_id)
+    if rev_id:
+        return (
+            f"OPERATION: MANUALLY_BACKUP_NOTE\n"
+            f"STATUS: SUCCESS\n"
+            f"NOTE_ID: {note_id}\n"
+            f"REVISION_ID: {rev_id}\n"
+            f"MESSAGE: Revision snapshot created. Recoverable via "
+            f"get_note_history + restore_note_revision or "
+            f"Joplin Desktop's Note History."
+        )
+    else:
+        return (
+            f"OPERATION: MANUALLY_BACKUP_NOTE\n"
+            f"STATUS: FAILED\n"
+            f"NOTE_ID: {note_id}\n"
+            f"MESSAGE: Failed to create revision snapshot. "
+            f"Check server logs for details."
+        )

--- a/src/joplin_mcp/tools/tags.py
+++ b/src/joplin_mcp/tools/tags.py
@@ -150,7 +150,7 @@ async def delete_tag(
     """
     client = get_joplin_client()
     client.delete_tag(tag_id)
-    return format_delete_success(ItemType.tag, tag_id)
+    return format_delete_success(ItemType.tag, tag_id, soft_delete=False)
 
 
 @create_tool("get_tags_by_note", "Get tags by note")

--- a/src/joplin_mcp/tools/tags_bulk.py
+++ b/src/joplin_mcp/tools/tags_bulk.py
@@ -1,0 +1,239 @@
+"""Bulk tag operation tools for Joplin MCP."""
+
+import logging
+from typing import Annotated, List
+
+from pydantic import Field
+
+from joplin_mcp.fastmcp_server import (
+    COMMON_NOTE_FIELDS,
+    JoplinIdType,
+    create_tool,
+    get_joplin_client,
+    get_tag_id_by_name,
+    process_search_results,
+    validate_joplin_id,
+)
+from joplin_mcp.formatting import ItemType
+from joplin_mcp.tools.tags import _tag_note_impl, _untag_note_impl
+
+logger = logging.getLogger(__name__)
+
+
+# === BULK TAG TOOLS ===
+
+
+@create_tool("strip_note_tags", "Remove all tags from note")
+async def strip_note_tags(
+    note_id: Annotated[
+        JoplinIdType,
+        Field(description="Note ID to remove all tags from"),
+    ],
+) -> str:
+    """Remove all tags from a specific note.
+
+    Removes all existing tags from a note, effectively clearing its tag
+    associations. Useful for resetting a note's categorisation or cleaning
+    up over-tagged notes.
+
+    Returns:
+        str: Success message with details of the tag removal operation.
+
+    Examples:
+        - strip_note_tags("a1b2c3d4e5f6...") - Remove all tags from specific note
+        - strip_note_tags("note_id_123") - Clear all tags from the note
+
+    Note: The note must exist (by ID). If the note has no tags, the operation
+    succeeds with no changes.
+    """
+    note_id = validate_joplin_id(note_id)
+    client = get_joplin_client()
+
+    # Verify note exists and get info (following alondmnt's pattern)
+    try:
+        note = client.get_note(note_id, fields=COMMON_NOTE_FIELDS)
+        note_title = getattr(note, "title", "Unknown Note")
+    except Exception:
+        raise ValueError(
+            f"Note with ID '{note_id}' not found. "
+            f"Use find_notes to find available notes."
+        )
+
+    # Get all tags currently on this note
+    try:
+        fields_list = "id,title,created_time,updated_time"
+        tags_result = client.get_tags(note_id=note_id, fields=fields_list)
+        note_tags = process_search_results(tags_result)
+    except Exception as e:
+        raise RuntimeError(
+            f"Failed to retrieve tags for note '{note_title}': {e}"
+        )
+
+    if not note_tags:
+        return (
+            f"OPERATION: STRIP_TAGS\n"
+            f"STATUS: SUCCESS\n"
+            f"NOTE_ID: {note_id}\n"
+            f"NOTE_TITLE: {note_title}\n"
+            f"TAGS_REMOVED: 0\n"
+            f"MESSAGE: Note already has no tags"
+        )
+
+    # Remove each tag from the note
+    successful_removals = []
+    failed_removals = []
+
+    for tag in note_tags:
+        tag_id = getattr(tag, "id", "")
+        tag_name = getattr(tag, "title", "Unknown Tag")
+        try:
+            client.delete(f"/tags/{tag_id}/notes/{note_id}")
+            successful_removals.append(tag_name)
+        except Exception as e:
+            failed_removals.append(f"'{tag_name}': {e}")
+
+    success_count = len(successful_removals)
+    total_count = len(note_tags)
+
+    if failed_removals:
+        result_lines = [
+            "OPERATION: STRIP_TAGS",
+            "STATUS: PARTIAL_SUCCESS",
+            f"NOTE_ID: {note_id}",
+            f"NOTE_TITLE: {note_title}",
+            f"TAGS_REMOVED: {success_count}/{total_count}",
+            f"REMOVED: {', '.join(successful_removals)}",
+            f"FAILED: {', '.join(failed_removals)}",
+        ]
+    else:
+        result_lines = [
+            "OPERATION: STRIP_TAGS",
+            "STATUS: SUCCESS",
+            f"NOTE_ID: {note_id}",
+            f"NOTE_TITLE: {note_title}",
+            f"TAGS_REMOVED: {success_count}",
+            f"REMOVED: {', '.join(successful_removals)}",
+        ]
+
+    return "\n".join(result_lines)
+
+
+@create_tool("bulk_tag_notes", "Bulk tag notes")
+async def bulk_tag_notes(
+    note_ids: Annotated[
+        List[str],
+        Field(description="List of note IDs to add tags to"),
+    ],
+    tag_names: Annotated[
+        List[str],
+        Field(description="List of tag names to add to each note"),
+    ],
+) -> str:
+    """Apply multiple tags to multiple notes in a single bulk operation.
+
+    Adds all specified tags to all specified notes (cartesian product). Each
+    tag will be applied to each note, creating comprehensive tagging across
+    multiple items.
+
+    Returns:
+        str: Detailed success message with operation statistics.
+
+    Examples:
+        - bulk_tag_notes(["note1", "note2"], ["Important", "Work"])
+        - bulk_tag_notes(["abc123", "def456", "ghi789"], ["Project-Alpha"])
+
+    Note: All notes must exist (by ID) and all tags must exist (by name).
+    Creates note-tag relationships for all combinations.
+    """
+    if not note_ids:
+        raise ValueError("At least one note ID must be provided")
+    if not tag_names:
+        raise ValueError("At least one tag name must be provided")
+
+    # Validate all note IDs
+    validated_note_ids = [validate_joplin_id(nid) for nid in note_ids]
+
+    client = get_joplin_client()
+
+    # Verify all notes exist and collect titles (following alondmnt's pattern)
+    note_titles = {}
+    for nid in validated_note_ids:
+        try:
+            note = client.get_note(nid, fields=COMMON_NOTE_FIELDS)
+            note_titles[nid] = getattr(note, "title", "Unknown Note")
+        except Exception:
+            raise ValueError(
+                f"Note with ID '{nid}' not found. "
+                f"Use find_notes to find available notes."
+            )
+
+    # Apply all tags to all notes (cartesian product)
+    successful_operations = []
+    failed_operations = []
+    total_operations = len(validated_note_ids) * len(tag_names)
+
+    for nid in validated_note_ids:
+        note_title = note_titles[nid]
+        for tag_name in tag_names:
+            try:
+                tag_id = get_tag_id_by_name(tag_name)
+                client.add_tag_to_note(tag_id, nid)
+                successful_operations.append(
+                    f"'{tag_name}' -> '{note_title}' ({nid[:8]}...)"
+                )
+            except Exception as e:
+                failed_operations.append(
+                    f"'{tag_name}' -> '{note_title}' ({nid[:8]}...): {e}"
+                )
+
+    success_count = len(successful_operations)
+    failure_count = len(failed_operations)
+
+    if failure_count == 0:
+        status = "SUCCESS"
+    elif success_count > 0:
+        status = "PARTIAL_SUCCESS"
+    else:
+        status = "FAILED"
+
+    result_parts = [
+        "OPERATION: BULK_TAG_NOTES",
+        f"STATUS: {status}",
+        f"NOTES_PROCESSED: {len(validated_note_ids)}",
+        f"TAGS_APPLIED: {len(tag_names)}",
+        f"TOTAL_OPERATIONS: {total_operations}",
+        f"SUCCESSFUL: {success_count}",
+        f"FAILED: {failure_count}",
+        "",
+    ]
+
+    if successful_operations:
+        result_parts.append("SUCCESSFUL_TAGS:")
+        for op in successful_operations:
+            result_parts.append(f"  {op}")
+        result_parts.append("")
+
+    if failed_operations:
+        result_parts.append("FAILED_TAGS:")
+        for op in failed_operations:
+            result_parts.append(f"  {op}")
+        result_parts.append("")
+
+    # Summary message
+    if failure_count == 0:
+        result_parts.append(
+            f"MESSAGE: Successfully applied {len(tag_names)} tag(s) to "
+            f"{len(validated_note_ids)} note(s) ({success_count} total operations)"
+        )
+    elif success_count > 0:
+        result_parts.append(
+            f"MESSAGE: Partially completed bulk tagging: "
+            f"{success_count} successful, {failure_count} failed"
+        )
+    else:
+        result_parts.append(
+            f"MESSAGE: Bulk tagging failed: "
+            f"all {total_operations} operations failed"
+        )
+
+    return "\n".join(result_parts)

--- a/src/joplin_mcp/tools/trash.py
+++ b/src/joplin_mcp/tools/trash.py
@@ -1,0 +1,190 @@
+"""Trash management tools for Joplin MCP — list and restore soft-deleted items."""
+import datetime as dt_module
+import logging
+from typing import Annotated, Optional
+
+from pydantic import Field
+
+from joplin_mcp.content_utils import format_timestamp
+from joplin_mcp.fastmcp_server import (
+    ItemType,
+    JoplinIdType,
+    LimitType,
+    OffsetType,
+    create_tool,
+    format_update_success,
+    get_joplin_client,
+    validate_joplin_id,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@create_tool("list_trash", "List trashed items")
+async def list_trash(
+    item_type: Annotated[
+        Optional[str],
+        Field(
+            description=(
+                "Filter by type: 'note', 'notebook', or None for both"
+                " (default: None)"
+            ),
+        ),
+    ] = None,
+    limit: Annotated[
+        LimitType, Field(description="Max results (1-100, default: 20)")
+    ] = 20,
+    offset: Annotated[
+        OffsetType,
+        Field(description="Skip count for pagination (default: 0)"),
+    ] = 0,
+) -> str:
+    """List items in Joplin's trash.
+
+    Shows notes and/or notebooks that have been soft-deleted (moved to trash).
+    These items can be restored with restore_from_trash.
+
+    Returns:
+        str: List of trashed items with title, ID, deletion date, and original
+             notebook.
+    """
+    client = get_joplin_client()
+    epoch_zero = dt_module.datetime(1970, 1, 1, 0, 0)
+    results = []
+
+    if item_type is None or item_type == "note":
+        notes = client.get_all_notes(
+            fields="id,title,deleted_time,parent_id,is_todo",
+            include_deleted=1,
+        )
+        trashed_notes = [
+            n
+            for n in notes
+            if getattr(n, "deleted_time", None)
+            and n.deleted_time != epoch_zero
+        ]
+        for n in trashed_notes:
+            results.append(
+                {
+                    "type": "note",
+                    "id": n.id,
+                    "title": getattr(n, "title", "Untitled"),
+                    "deleted_time": n.deleted_time,
+                    "parent_id": getattr(n, "parent_id", ""),
+                    "is_todo": getattr(n, "is_todo", False),
+                }
+            )
+
+    if item_type is None or item_type == "notebook":
+        notebooks = client.get_all_notebooks(
+            fields="id,title,deleted_time,parent_id",
+            include_deleted=1,
+        )
+        trashed_notebooks = [
+            n
+            for n in notebooks
+            if getattr(n, "deleted_time", None)
+            and n.deleted_time != epoch_zero
+        ]
+        for n in trashed_notebooks:
+            results.append(
+                {
+                    "type": "notebook",
+                    "id": n.id,
+                    "title": getattr(n, "title", "Untitled"),
+                    "deleted_time": n.deleted_time,
+                    "parent_id": getattr(n, "parent_id", ""),
+                }
+            )
+
+    # Sort by deletion time, most recent first
+    results.sort(key=lambda x: x["deleted_time"], reverse=True)
+
+    total_count = len(results)
+
+    # Apply pagination
+    paginated = results[offset : offset + limit]
+
+    if not paginated:
+        return "TRASH_ITEMS: 0\nSTATUS: Trash is empty"
+
+    # Build notebook name lookup for parent_id display
+    try:
+        all_notebooks = client.get_all_notebooks(
+            fields="id,title", include_deleted=1
+        )
+        nb_map = {
+            getattr(nb, "id", ""): getattr(nb, "title", "Unknown")
+            for nb in all_notebooks
+        }
+    except Exception:
+        nb_map = {}
+
+    lines = [
+        f"TRASH_ITEMS: {total_count}",
+        f"SHOWING: {offset + 1}-{offset + len(paginated)} of {total_count}",
+        "",
+    ]
+
+    for i, item in enumerate(paginated, offset + 1):
+        deleted_str = format_timestamp(item["deleted_time"])
+        parent_name = nb_map.get(
+            item["parent_id"], item["parent_id"][:12] + "..."
+        )
+        lines.append(f"ITEM_{i}:")
+        lines.append(f"  type: {item['type']}")
+        lines.append(f"  id: {item['id']}")
+        lines.append(f"  title: {item['title']}")
+        lines.append(f"  deleted: {deleted_str}")
+        lines.append(f"  original_notebook: {parent_name}")
+        if item["type"] == "note" and item.get("is_todo"):
+            lines.append("  is_todo: true")
+
+    return "\n".join(lines)
+
+
+@create_tool("restore_from_trash", "Restore item from trash")
+async def restore_from_trash(
+    item_id: Annotated[
+        JoplinIdType,
+        Field(description="Note or notebook ID to restore"),
+    ],
+    item_type: Annotated[
+        str,
+        Field(description="Item type: 'note' or 'notebook'"),
+    ] = "note",
+) -> str:
+    """Restore a note or notebook from Joplin's trash.
+
+    Restores a previously deleted item by setting its deleted_time back to 0.
+    The item reappears in its original notebook. If the original notebook was
+    also trashed, restore it first or the note may not be visible.
+
+    Returns:
+        str: Success message confirming the item was restored.
+    """
+    item_id = validate_joplin_id(item_id)
+    client = get_joplin_client()
+
+    if item_type == "note":
+        client.modify_note(item_id, deleted_time=0)
+        return (
+            "OPERATION: RESTORE_FROM_TRASH\n"
+            "STATUS: SUCCESS\n"
+            "ITEM_TYPE: note\n"
+            f"ITEM_ID: {item_id}\n"
+            "MESSAGE: Note restored from trash to its original notebook"
+        )
+    elif item_type == "notebook":
+        client.modify_notebook(item_id, deleted_time=0)
+        return (
+            "OPERATION: RESTORE_FROM_TRASH\n"
+            "STATUS: SUCCESS\n"
+            "ITEM_TYPE: notebook\n"
+            f"ITEM_ID: {item_id}\n"
+            "MESSAGE: Notebook restored from trash"
+        )
+    else:
+        raise ValueError(
+            f"item_type must be 'note' or 'notebook', got '{item_type}'"
+        )

--- a/tests/pr_tests.py
+++ b/tests/pr_tests.py
@@ -1,0 +1,1084 @@
+"""Unit tests for PR contributions: field helpers, search, and bulk operations.
+
+Uses mocked Joplin client. To test versioned scripts side-by-side, uncomment
+ALT_MODULE and the parameterized fixture below.
+"""
+
+import importlib
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+MODULE = "joplin_mcp.tools.field_helpers"
+# ALT_MODULE = "joplin_mcp.tools.field_helpers_v1"  # uncomment for side-by-side
+
+_MODULES = [MODULE]
+# _MODULES = [MODULE, ALT_MODULE]  # uncomment for side-by-side
+
+
+@pytest.fixture(params=_MODULES)
+def helpers(request):
+    """Import field_helpers. Parameterized for side-by-side version testing."""
+    return importlib.import_module(request.param)
+
+
+# ---------------------------------------------------------------------------
+# Mock notes
+# ---------------------------------------------------------------------------
+
+
+def _make_note(**kwargs):
+    defaults = {
+        "id": "a" * 32,
+        "title": "Test Note",
+        "body": "Test body content",
+        "created_time": 1700000000000,
+        "updated_time": 1700000000000,
+        "parent_id": "b" * 32,
+        "is_todo": 0,
+        "todo_completed": 0,
+        "todo_due": 0,
+        "author": "",
+        "source_url": "",
+        "latitude": 0.0,
+        "longitude": 0.0,
+        "altitude": 0.0,
+        "markup_language": 1,
+        "user_created_time": 0,
+        "user_updated_time": 0,
+        "deleted_time": 0,
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+MOCK_NOTES = [
+    _make_note(id="a" * 32, title="Meeting Notes", is_todo=0, author="Alice"),
+    _make_note(id="b" * 32, title="Todo Item", is_todo=1, todo_completed=0, author="Bob"),
+    _make_note(id="c" * 32, title="Done Item", is_todo=1, todo_completed=1700000000000, author="Alice"),
+    _make_note(id="d" * 32, title="Draft", is_todo=0, author=""),
+]
+
+
+# ===========================================================================
+# convert_todo_completed — identical in both versions
+# ===========================================================================
+
+
+class TestConvertTodoCompleted:
+
+    def test_none(self, helpers):
+        value, warning = helpers.convert_todo_completed(None)
+        assert value is None
+        assert warning is None
+
+    def test_true(self, helpers):
+        before = int(time.time() * 1000)
+        value, warning = helpers.convert_todo_completed(True)
+        after = int(time.time() * 1000)
+        assert before <= value <= after
+        assert warning is None
+
+    def test_false(self, helpers):
+        value, _ = helpers.convert_todo_completed(False)
+        assert value == 0
+
+    @pytest.mark.parametrize("s", ["true", "True", "TRUE", "yes", "on"])
+    def test_string_true(self, helpers, s):
+        value, _ = helpers.convert_todo_completed(s)
+        assert value > 0
+
+    @pytest.mark.parametrize("s", ["false", "False", "no", "off"])
+    def test_string_false(self, helpers, s):
+        value, _ = helpers.convert_todo_completed(s)
+        assert value == 0
+
+    def test_iso_datetime(self, helpers):
+        value, _ = helpers.convert_todo_completed("2025-06-15 10:30")
+        assert value > 0
+
+    def test_iso_date_only(self, helpers):
+        value, _ = helpers.convert_todo_completed("2025-06-15")
+        assert value > 0
+
+    def test_epoch_ms_passthrough(self, helpers):
+        value, _ = helpers.convert_todo_completed(1700000000000)
+        assert value == 1700000000000
+
+    def test_zero(self, helpers):
+        value, _ = helpers.convert_todo_completed(0)
+        assert value == 0
+
+    def test_small_int_warns(self, helpers):
+        value, warning = helpers.convert_todo_completed(42)
+        assert value == 42
+        assert warning is not None and "WARNING" in warning
+
+    def test_invalid_string_raises(self, helpers):
+        with pytest.raises(ValueError, match="Unrecognized"):
+            helpers.convert_todo_completed("not-a-date")
+
+    def test_invalid_type_raises(self, helpers):
+        with pytest.raises(ValueError, match="Invalid"):
+            helpers.convert_todo_completed([1, 2, 3])
+
+
+# ===========================================================================
+# JOPLIN_NOTE_FIELDS registry — identical in both versions
+# ===========================================================================
+
+
+class TestFieldRegistry:
+
+    def test_has_common_fields(self, helpers):
+        for field in ["title", "body", "is_todo", "todo_completed", "parent_id", "todo_due"]:
+            assert field in helpers.JOPLIN_NOTE_FIELDS, f"Missing: {field}"
+
+    def test_has_extra_fields(self, helpers):
+        for field in ["author", "source_url", "latitude", "longitude", "altitude"]:
+            assert field in helpers.JOPLIN_NOTE_FIELDS, f"Missing: {field}"
+
+    def test_each_field_has_callable_converter(self, helpers):
+        for name, info in helpers.JOPLIN_NOTE_FIELDS.items():
+            assert "type_converter" in info, f"{name}: missing type_converter"
+            assert callable(info["type_converter"]), f"{name}: not callable"
+
+    def test_is_todo_converter(self, helpers):
+        conv = helpers.JOPLIN_NOTE_FIELDS["is_todo"]["type_converter"]
+        assert conv("true") is True
+        assert conv("false") is False
+        assert conv(None) is None
+
+    def test_todo_completed_converter(self, helpers):
+        conv = helpers.JOPLIN_NOTE_FIELDS["todo_completed"]["type_converter"]
+        result = conv(True)
+        assert result > 1_000_000_000_000  # epoch ms
+
+    def test_title_converter_is_identity(self, helpers):
+        conv = helpers.JOPLIN_NOTE_FIELDS["title"]["type_converter"]
+        assert conv("hello") == "hello"
+
+
+# ===========================================================================
+# extract_note_ids_from_result — identical in both versions
+# ===========================================================================
+
+
+SAMPLE_FORMATTED_OUTPUT = """SEARCH_QUERY: test
+TOTAL_RESULTS: 3
+
+RESULT_1:
+  note_id: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  title: Note A
+
+RESULT_2:
+  note_id: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+  title: Note B
+
+RESULT_3:
+  note_id: cccccccccccccccccccccccccccccccc
+  title: Note C
+"""
+
+
+class TestExtractNoteIds:
+
+    def test_extracts_all(self, helpers):
+        ids = helpers.extract_note_ids_from_result(SAMPLE_FORMATTED_OUTPUT, 10)
+        assert ids == ["a" * 32, "b" * 32, "c" * 32]
+
+    def test_respects_limit(self, helpers):
+        ids = helpers.extract_note_ids_from_result(SAMPLE_FORMATTED_OUTPUT, 2)
+        assert len(ids) == 2
+
+    def test_empty_input(self, helpers):
+        assert helpers.extract_note_ids_from_result("", 10) == []
+
+    def test_no_matches(self, helpers):
+        assert helpers.extract_note_ids_from_result("just text\nno ids here", 10) == []
+
+
+# ===========================================================================
+# Parameter parsing: v1 generate_field_pars vs v2 _parse_update_params
+# Both should identify the same updates and filters from the same input.
+# ===========================================================================
+
+
+class TestParamParsing:
+    """Tests that v1 and v2 produce equivalent update/filter separation."""
+
+    def _parse(self, helpers, **kwargs):
+        """Unified interface: returns (update_field_names, filter_field_names)."""
+        if hasattr(helpers, "_parse_update_params"):
+            # v2
+            updates, filters = helpers._parse_update_params(**kwargs)
+            return set(updates.keys()), set(filters.keys())
+        else:
+            # v1
+            result = helpers.generate_field_pars(**kwargs)
+            return set(result["update_fields"]), set(result["filter_fields"])
+
+    def test_basic_separation(self, helpers):
+        updates, filters = self._parse(
+            helpers, title="New Title", is_todo=True, author_filter="Alice"
+        )
+        assert "title" in updates
+        assert "is_todo" in updates
+        assert "author" in filters
+
+    def test_none_values_ignored(self, helpers):
+        updates, filters = self._parse(helpers, title=None, body=None)
+        assert updates == set()
+        assert filters == set()
+
+    def test_unknown_keys_ignored(self, helpers):
+        updates, filters = self._parse(
+            helpers, query="test", expected_count=5, title="X"
+        )
+        assert updates == {"title"}
+        assert filters == set()
+
+    def test_update_and_filter_on_same_field(self, helpers):
+        updates, filters = self._parse(
+            helpers, is_todo=True, is_todo_filter=False
+        )
+        assert "is_todo" in updates
+        assert "is_todo" in filters
+
+    def test_multiple_filters(self, helpers):
+        _, filters = self._parse(
+            helpers, author_filter="Alice", is_todo_filter=True
+        )
+        assert filters == {"author", "is_todo"}
+
+
+# ===========================================================================
+# v2-only: _search_notes with filtering
+# ===========================================================================
+
+
+class TestSearchNotes:
+    """Tests for _search_notes: search + post-fetch filtering."""
+
+    def _mock_client(self, notes=None):
+        client = MagicMock()
+        notes = notes or MOCK_NOTES
+        client.search_all.return_value = notes
+        client.get_all_notes.return_value = notes
+        return client
+
+    def _get_search(self):
+        mod = importlib.import_module(MODULE)
+        return mod._search_notes, mod.ALL_NOTE_FIELDS
+
+    @patch(f"{MODULE}.process_search_results", side_effect=lambda x: x)
+    def test_no_filters_returns_all(self, mock_proc):
+        search, _ = self._get_search()
+        matching, skipped = search(self._mock_client(), "test")
+        assert len(matching) == 4
+        assert skipped == 0
+
+    @patch(f"{MODULE}.process_search_results", side_effect=lambda x: x)
+    def test_wildcard_uses_get_all(self, mock_proc):
+        search, _ = self._get_search()
+        client = self._mock_client()
+        search(client, "*")
+        client.get_all_notes.assert_called_once()
+        client.search_all.assert_not_called()
+
+    @patch(f"{MODULE}.process_search_results", side_effect=lambda x: x)
+    def test_text_query_uses_search_all(self, mock_proc):
+        search, _ = self._get_search()
+        client = self._mock_client()
+        search(client, "meeting notes")
+        client.search_all.assert_called_once()
+        client.get_all_notes.assert_not_called()
+
+    @patch(f"{MODULE}.process_search_results", side_effect=lambda x: x)
+    def test_filter_by_author(self, mock_proc):
+        search, _ = self._get_search()
+        matching, skipped = search(self._mock_client(), "*", author="Alice")
+        assert len(matching) == 2
+        assert skipped == 2
+
+    @patch(f"{MODULE}.process_search_results", side_effect=lambda x: x)
+    def test_filter_by_is_todo(self, mock_proc):
+        search, _ = self._get_search()
+        matching, skipped = search(self._mock_client(), "*", is_todo=1)
+        assert len(matching) == 2
+        assert skipped == 2
+
+    @patch(f"{MODULE}.process_search_results", side_effect=lambda x: x)
+    def test_and_filters(self, mock_proc):
+        search, _ = self._get_search()
+        matching, skipped = search(self._mock_client(), "*", is_todo=1, author="Alice")
+        assert len(matching) == 1  # Done Item only
+        assert skipped == 3
+
+    @patch(f"{MODULE}.process_search_results", side_effect=lambda x: x)
+    def test_no_matches(self, mock_proc):
+        search, _ = self._get_search()
+        matching, skipped = search(self._mock_client(), "*", author="Charlie")
+        assert len(matching) == 0
+        assert skipped == 4
+
+    @patch(f"{MODULE}.process_search_results", side_effect=lambda x: x)
+    def test_query_passed_untouched(self, mock_proc):
+        search, all_fields = self._get_search()
+        client = self._mock_client()
+        search(client, 'notebook:"Work" title:meeting')
+        call_kwargs = client.search_all.call_args[1]
+        assert call_kwargs["query"] == 'notebook:"Work" title:meeting'
+        assert call_kwargs["fields"] == all_fields
+
+    @patch(f"{MODULE}.process_search_results", side_effect=lambda x: x)
+    def test_all_fields_requested(self, mock_proc):
+        """Verify ALL_NOTE_FIELDS includes both common and extra fields."""
+        search, all_fields = self._get_search()
+        client = self._mock_client()
+        search(client, "test")
+        call_kwargs = client.search_all.call_args[1]
+        for field in ["id", "title", "body", "author", "source_url", "latitude"]:
+            assert field in call_kwargs["fields"], f"Missing field: {field}"
+
+    def test_no_extract_query_fields(self):
+        """Query goes to Joplin untouched — no field name parsing."""
+        mod = importlib.import_module(MODULE)
+        assert not hasattr(mod, "extract_query_fields")
+
+
+# ===========================================================================
+# backup_database
+# ===========================================================================
+
+
+class TestBackupDatabase:
+
+    @patch("joplin_mcp.tools.backup_database.subprocess.run")
+    @patch("joplin_mcp.tools.backup_database._get_joplin_db_path")
+    def test_auto_backup(self, mock_path, mock_run):
+        from pathlib import Path
+        import tempfile
+        from joplin_mcp.tools.backup_database import backup_joplin_database
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mock_path.return_value = Path(tmpdir) / "database.sqlite"
+            (Path(tmpdir) / "database.sqlite").touch()
+            mock_run.return_value = MagicMock(returncode=0, stderr="")
+
+            with patch("joplin_mcp.tools.backup_database._BACKUP_DIR", Path(tmpdir) / "backups"):
+                result = backup_joplin_database(force=False)
+            assert result is not None
+            assert "auto_backup" in result
+
+    @patch("joplin_mcp.tools.backup_database.subprocess.run")
+    @patch("joplin_mcp.tools.backup_database._get_joplin_db_path")
+    def test_manual_backup(self, mock_path, mock_run):
+        from pathlib import Path
+        import tempfile
+        from joplin_mcp.tools.backup_database import backup_joplin_database
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mock_path.return_value = Path(tmpdir) / "database.sqlite"
+            (Path(tmpdir) / "database.sqlite").touch()
+            mock_run.return_value = MagicMock(returncode=0, stderr="")
+
+            with patch("joplin_mcp.tools.backup_database._BACKUP_DIR", Path(tmpdir) / "backups"):
+                result = backup_joplin_database(force=True)
+            assert result is not None
+            assert "manual_backup" in result
+
+    def test_missing_db(self):
+        from joplin_mcp.tools.backup_database import backup_joplin_database
+        with patch("joplin_mcp.tools.backup_database._get_joplin_db_path",
+                    side_effect=FileNotFoundError):
+            assert backup_joplin_database() is None
+
+
+# ===========================================================================
+# revision_utils
+# ===========================================================================
+
+
+class TestRevisionUtils:
+
+    def test_apply_diff_legacy(self):
+        from joplin_mcp.revision_utils import _apply_diff
+        import diff_match_patch as dmp_module
+        dmp = dmp_module.diff_match_patch()
+
+        patches = dmp.patch_make("hello", "hello world")
+        diff_text = dmp.patch_toText(patches)
+        assert _apply_diff(diff_text, "hello") == "hello world"
+
+    def test_apply_diff_from_empty(self):
+        from joplin_mcp.revision_utils import _apply_diff
+        import diff_match_patch as dmp_module
+        dmp = dmp_module.diff_match_patch()
+
+        patches = dmp.patch_make("", "new content")
+        diff_text = dmp.patch_toText(patches)
+        assert _apply_diff(diff_text, "") == "new content"
+
+    def test_save_revision_success(self):
+        from joplin_mcp.revision_utils import save_note_revision
+
+        client = MagicMock()
+        client.get_note.return_value = SimpleNamespace(
+            id="a" * 32, title="Test", body="Content",
+            parent_id="b" * 32, is_todo=0, todo_completed=0,
+        )
+        client.get_all_revisions.return_value = []
+        client.add_revision.return_value = "rev123"
+
+        assert save_note_revision(client, "a" * 32) == "rev123"
+        client.add_revision.assert_called_once()
+
+    def test_save_revision_failure(self):
+        from joplin_mcp.revision_utils import save_note_revision
+
+        client = MagicMock()
+        client.get_note.side_effect = Exception("Not found")
+        assert save_note_revision(client, "a" * 32) is None
+
+
+# ===========================================================================
+# GROUP 1: Single-note MCP tool tests
+# (move_note, update_note, edit_note, manually_backup_note)
+# ===========================================================================
+
+NOTE_ID = "a" * 32
+NOTEBOOK_ID = "b" * 32
+
+
+class TestMoveNoteTool:
+    """Tests for move_note MCP tool."""
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes_bulk.get_notebook_id_by_name")
+    @patch("joplin_mcp.tools.notes_bulk.get_joplin_client")
+    async def test_move_by_notebook_name(self, mock_get_client, mock_get_nb):
+        from joplin_mcp.tools.notes_bulk import move_note
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_get_nb.return_value = NOTEBOOK_ID
+
+        result = await move_note.fn(NOTE_ID, target_notebook="Archive")
+
+        mock_get_nb.assert_called_once_with("Archive")
+        mock_client.modify_note.assert_called_once_with(NOTE_ID, parent_id=NOTEBOOK_ID)
+        assert "UPDATE_NOTE" in result
+        assert "SUCCESS" in result
+        assert NOTEBOOK_ID in result
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes_bulk.get_joplin_client")
+    async def test_move_by_notebook_id(self, mock_get_client):
+        from joplin_mcp.tools.notes_bulk import move_note
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        result = await move_note.fn(NOTE_ID, target_notebook_id=NOTEBOOK_ID)
+
+        mock_client.modify_note.assert_called_once_with(NOTE_ID, parent_id=NOTEBOOK_ID)
+        assert "SUCCESS" in result
+
+    @pytest.mark.asyncio
+    async def test_error_no_target(self):
+        from joplin_mcp.tools.notes_bulk import move_note
+
+        with pytest.raises(ValueError, match="Must specify"):
+            await move_note.fn(NOTE_ID)
+
+    @pytest.mark.asyncio
+    async def test_error_both_targets(self):
+        from joplin_mcp.tools.notes_bulk import move_note
+
+        with pytest.raises(ValueError, match="Cannot specify both"):
+            await move_note.fn(NOTE_ID, target_notebook="X", target_notebook_id=NOTEBOOK_ID)
+
+
+class TestUpdateNoteAutoBackup:
+    """Tests for our enhancements to update_note: auto-backup + convert_todo_completed."""
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes.save_note_revision")
+    @patch("joplin_mcp.tools.notes.get_joplin_client")
+    async def test_auto_backup_on_body_change(self, mock_get_client, mock_save_rev):
+        from joplin_mcp.tools.notes import update_note
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        await update_note.fn(NOTE_ID, body="New body content")
+
+        mock_save_rev.assert_called_once_with(mock_client, NOTE_ID)
+        mock_client.modify_note.assert_called_once()
+        assert mock_client.modify_note.call_args[1]["body"] == "New body content"
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes.save_note_revision")
+    @patch("joplin_mcp.tools.notes.get_joplin_client")
+    async def test_auto_backup_on_title_change(self, mock_get_client, mock_save_rev):
+        from joplin_mcp.tools.notes import update_note
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        await update_note.fn(NOTE_ID, title="New Title")
+
+        mock_save_rev.assert_called_once_with(mock_client, NOTE_ID)
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes.save_note_revision")
+    @patch("joplin_mcp.tools.notes.get_joplin_client")
+    async def test_no_backup_on_metadata_only(self, mock_get_client, mock_save_rev):
+        from joplin_mcp.tools.notes import update_note
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        await update_note.fn(NOTE_ID, is_todo=True)
+
+        mock_save_rev.assert_not_called()
+        assert mock_client.modify_note.call_args[1]["is_todo"] == 1
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes.save_note_revision")
+    @patch("joplin_mcp.tools.notes.get_joplin_client")
+    async def test_backup_failure_doesnt_block_update(self, mock_get_client, mock_save_rev):
+        from joplin_mcp.tools.notes import update_note
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_save_rev.side_effect = Exception("Revision failed")
+
+        result = await update_note.fn(NOTE_ID, body="New content")
+
+        # Update should still succeed despite backup failure
+        mock_client.modify_note.assert_called_once()
+        assert "SUCCESS" in result
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes.save_note_revision")
+    @patch("joplin_mcp.tools.notes.get_joplin_client")
+    async def test_todo_completed_true_sets_epoch_ms(self, mock_get_client, mock_save_rev):
+        from joplin_mcp.tools.notes import update_note
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        before = int(time.time() * 1000)
+        await update_note.fn(NOTE_ID, todo_completed=True)
+        after = int(time.time() * 1000)
+
+        call_kwargs = mock_client.modify_note.call_args[1]
+        assert before <= call_kwargs["todo_completed"] <= after
+        # Auto-sets is_todo=1 when marking complete
+        assert call_kwargs["is_todo"] == 1
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes.save_note_revision")
+    @patch("joplin_mcp.tools.notes.get_joplin_client")
+    async def test_todo_completed_false_sets_zero(self, mock_get_client, mock_save_rev):
+        from joplin_mcp.tools.notes import update_note
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        await update_note.fn(NOTE_ID, todo_completed=False)
+
+        call_kwargs = mock_client.modify_note.call_args[1]
+        assert call_kwargs["todo_completed"] == 0
+
+
+class TestEditNoteAutoBackup:
+    """Tests for our auto-backup enhancement to edit_note."""
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes.save_note_revision")
+    @patch("joplin_mcp.tools.notes.get_joplin_client")
+    async def test_backup_before_replace(self, mock_get_client, mock_save_rev):
+        from joplin_mcp.tools.notes import edit_note
+
+        mock_client = MagicMock()
+        mock_note = MagicMock()
+        mock_note.body = "Hello world"
+        mock_client.get_note.return_value = mock_note
+        mock_get_client.return_value = mock_client
+
+        await edit_note.fn(NOTE_ID, new_string="Hello universe", old_string="Hello world")
+
+        mock_save_rev.assert_called_once_with(mock_client, NOTE_ID)
+        mock_client.modify_note.assert_called_once()
+        assert mock_client.modify_note.call_args[1]["body"] == "Hello universe"
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes.save_note_revision")
+    @patch("joplin_mcp.tools.notes.get_joplin_client")
+    async def test_backup_before_append(self, mock_get_client, mock_save_rev):
+        from joplin_mcp.tools.notes import edit_note
+
+        mock_client = MagicMock()
+        mock_note = MagicMock()
+        mock_note.body = "Original"
+        mock_client.get_note.return_value = mock_note
+        mock_get_client.return_value = mock_client
+
+        await edit_note.fn(NOTE_ID, new_string=" appended", position="end")
+
+        mock_save_rev.assert_called_once()
+        assert mock_client.modify_note.call_args[1]["body"] == "Original appended"
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes.save_note_revision")
+    @patch("joplin_mcp.tools.notes.get_joplin_client")
+    async def test_backup_failure_doesnt_block_edit(self, mock_get_client, mock_save_rev):
+        from joplin_mcp.tools.notes import edit_note
+
+        mock_client = MagicMock()
+        mock_note = MagicMock()
+        mock_note.body = "Hello world"
+        mock_client.get_note.return_value = mock_note
+        mock_get_client.return_value = mock_client
+        mock_save_rev.side_effect = Exception("Backup failed")
+
+        result = await edit_note.fn(NOTE_ID, new_string="Hello universe", old_string="Hello world")
+
+        mock_client.modify_note.assert_called_once()
+        assert "Replaced" in result
+
+
+class TestManuallyBackupNoteTool:
+    """Tests for manually_backup_note MCP tool."""
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes_revisions.save_note_revision")
+    @patch("joplin_mcp.tools.notes_revisions.get_joplin_client")
+    async def test_success(self, mock_get_client, mock_save_rev):
+        from joplin_mcp.tools.notes_revisions import manually_backup_note
+
+        mock_get_client.return_value = MagicMock()
+        mock_save_rev.return_value = "rev_" + "x" * 28
+
+        result = await manually_backup_note.fn(NOTE_ID)
+
+        assert "MANUALLY_BACKUP_NOTE" in result
+        assert "SUCCESS" in result
+        assert "rev_" in result
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes_revisions.save_note_revision")
+    @patch("joplin_mcp.tools.notes_revisions.get_joplin_client")
+    async def test_failure(self, mock_get_client, mock_save_rev):
+        from joplin_mcp.tools.notes_revisions import manually_backup_note
+
+        mock_get_client.return_value = MagicMock()
+        mock_save_rev.return_value = None
+
+        result = await manually_backup_note.fn(NOTE_ID)
+
+        assert "FAILED" in result
+
+
+# ===========================================================================
+# GROUP 2: Bulk MCP tool tests
+# (bulk_move_notes, search_and_bulk_update_preview/execute,
+#  bulk_tag_notes, strip_note_tags)
+# ===========================================================================
+
+
+class TestBulkMoveNotesTool:
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes_bulk.backup_joplin_database")
+    @patch("joplin_mcp.tools.notes_bulk.get_notebook_id_by_name")
+    @patch("joplin_mcp.tools.notes_bulk.get_joplin_client")
+    async def test_moves_all_notes(self, mock_get_client, mock_get_nb, mock_backup):
+        from joplin_mcp.tools.notes_bulk import bulk_move_notes
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_get_nb.return_value = NOTEBOOK_ID
+
+        ids = ["a" * 32, "b" * 32, "c" * 32]
+        result = await bulk_move_notes.fn(ids, target_notebook="Archive")
+
+        assert mock_client.modify_note.call_count == 3
+        assert "moved_successfully: 3" in result
+        assert "success" in result
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes_bulk.backup_joplin_database")
+    @patch("joplin_mcp.tools.notes_bulk.get_notebook_id_by_name")
+    @patch("joplin_mcp.tools.notes_bulk.get_joplin_client")
+    async def test_backup_called_daily(self, mock_get_client, mock_get_nb, mock_backup):
+        from joplin_mcp.tools.notes_bulk import bulk_move_notes
+
+        mock_get_client.return_value = MagicMock()
+        mock_get_nb.return_value = NOTEBOOK_ID
+
+        await bulk_move_notes.fn(["a" * 32], target_notebook="X")
+
+        mock_backup.assert_called_once_with(force=False)
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes_bulk.backup_joplin_database")
+    @patch("joplin_mcp.tools.notes_bulk.get_notebook_id_by_name")
+    @patch("joplin_mcp.tools.notes_bulk.get_joplin_client")
+    async def test_backup_force(self, mock_get_client, mock_get_nb, mock_backup):
+        from joplin_mcp.tools.notes_bulk import bulk_move_notes
+
+        mock_get_client.return_value = MagicMock()
+        mock_get_nb.return_value = NOTEBOOK_ID
+
+        await bulk_move_notes.fn(["a" * 32], target_notebook="X", backup="force")
+
+        mock_backup.assert_called_once_with(force=True)
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes_bulk.backup_joplin_database")
+    @patch("joplin_mcp.tools.notes_bulk.get_notebook_id_by_name")
+    @patch("joplin_mcp.tools.notes_bulk.get_joplin_client")
+    async def test_backup_suppress(self, mock_get_client, mock_get_nb, mock_backup):
+        from joplin_mcp.tools.notes_bulk import bulk_move_notes
+
+        mock_get_client.return_value = MagicMock()
+        mock_get_nb.return_value = NOTEBOOK_ID
+
+        await bulk_move_notes.fn(["a" * 32], target_notebook="X", backup="suppress")
+
+        mock_backup.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes_bulk.backup_joplin_database")
+    @patch("joplin_mcp.tools.notes_bulk.get_notebook_id_by_name")
+    @patch("joplin_mcp.tools.notes_bulk.get_joplin_client")
+    async def test_partial_failure(self, mock_get_client, mock_get_nb, mock_backup):
+        from joplin_mcp.tools.notes_bulk import bulk_move_notes
+
+        mock_client = MagicMock()
+        mock_client.modify_note.side_effect = [None, Exception("Not found"), None]
+        mock_get_client.return_value = mock_client
+        mock_get_nb.return_value = NOTEBOOK_ID
+
+        ids = ["a" * 32, "b" * 32, "c" * 32]
+        result = await bulk_move_notes.fn(ids, target_notebook="Archive")
+
+        assert "moved_successfully: 2" in result
+        assert "partial_success" in result
+        assert "failed_moves: 1" in result
+
+
+class TestStripNoteTagsTool:
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.tags_bulk.process_search_results")
+    @patch("joplin_mcp.tools.tags_bulk.get_joplin_client")
+    async def test_strips_all_tags(self, mock_get_client, mock_process):
+        from joplin_mcp.tools.tags_bulk import strip_note_tags
+
+        mock_client = MagicMock()
+        mock_note = SimpleNamespace(title="Test Note")
+        mock_client.get_note.return_value = mock_note
+        mock_get_client.return_value = mock_client
+
+        tags = [
+            SimpleNamespace(id="t" * 32, title="tag-a"),
+            SimpleNamespace(id="u" * 32, title="tag-b"),
+        ]
+        mock_process.return_value = tags
+
+        result = await strip_note_tags.fn(NOTE_ID)
+
+        assert "STRIP_TAGS" in result
+        assert "SUCCESS" in result
+        assert "TAGS_REMOVED: 2" in result
+        assert mock_client.delete.call_count == 2
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.tags_bulk.process_search_results")
+    @patch("joplin_mcp.tools.tags_bulk.get_joplin_client")
+    async def test_no_tags(self, mock_get_client, mock_process):
+        from joplin_mcp.tools.tags_bulk import strip_note_tags
+
+        mock_client = MagicMock()
+        mock_client.get_note.return_value = SimpleNamespace(title="Test")
+        mock_get_client.return_value = mock_client
+        mock_process.return_value = []
+
+        result = await strip_note_tags.fn(NOTE_ID)
+
+        assert "TAGS_REMOVED: 0" in result
+        assert "already has no tags" in result
+
+
+class TestBulkTagNotesTool:
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.tags_bulk.get_tag_id_by_name")
+    @patch("joplin_mcp.tools.tags_bulk.get_joplin_client")
+    async def test_tags_all_notes(self, mock_get_client, mock_get_tag):
+        from joplin_mcp.tools.tags_bulk import bulk_tag_notes
+
+        mock_client = MagicMock()
+        mock_client.get_note.return_value = SimpleNamespace(title="Note")
+        mock_get_client.return_value = mock_client
+        mock_get_tag.return_value = "t" * 32
+
+        ids = ["a" * 32, "b" * 32]
+        result = await bulk_tag_notes.fn(ids, ["work", "urgent"])
+
+        assert "BULK_TAG_NOTES" in result
+        assert "SUCCESS" in result
+        assert "TOTAL_OPERATIONS: 4" in result
+        assert mock_client.add_tag_to_note.call_count == 4
+
+    @pytest.mark.asyncio
+    async def test_error_empty_note_ids(self):
+        from joplin_mcp.tools.tags_bulk import bulk_tag_notes
+
+        with pytest.raises(ValueError, match="At least one note"):
+            await bulk_tag_notes.fn([], ["tag"])
+
+    @pytest.mark.asyncio
+    async def test_error_empty_tag_names(self):
+        from joplin_mcp.tools.tags_bulk import bulk_tag_notes
+
+        with pytest.raises(ValueError, match="At least one tag"):
+            await bulk_tag_notes.fn(["a" * 32], [])
+
+
+# ===========================================================================
+# GROUP 3: Trash, revision, and backup MCP tool tests
+# (list_trash, restore_from_trash, get_note_history,
+#  restore_note_revision, backup_database)
+# ===========================================================================
+
+
+class TestListTrashTool:
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.trash.format_timestamp", return_value="2026-03-27 20:19")
+    @patch("joplin_mcp.tools.trash.get_joplin_client")
+    async def test_lists_trashed_notes(self, mock_get_client, mock_fmt_ts):
+        from joplin_mcp.tools.trash import list_trash
+        import datetime as dt_module
+
+        mock_client = MagicMock()
+        trashed = SimpleNamespace(
+            id="a" * 32, title="Deleted Note",
+            deleted_time=dt_module.datetime(2026, 3, 27, 20, 19),
+            parent_id="b" * 32, is_todo=0,
+        )
+        active = SimpleNamespace(
+            id="c" * 32, title="Active Note",
+            deleted_time=dt_module.datetime(1970, 1, 1, 0, 0),
+            parent_id="b" * 32, is_todo=0,
+        )
+        mock_client.get_all_notes.return_value = [trashed, active]
+        mock_client.get_all_notebooks.return_value = [
+            SimpleNamespace(id="b" * 32, title="Testing"),
+        ]
+        mock_get_client.return_value = mock_client
+
+        result = await list_trash.fn(item_type="note")
+
+        assert "TRASH_ITEMS: 1" in result
+        assert "Deleted Note" in result
+        assert "Testing" in result
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.trash.get_joplin_client")
+    async def test_empty_trash(self, mock_get_client):
+        from joplin_mcp.tools.trash import list_trash
+        import datetime as dt_module
+
+        mock_client = MagicMock()
+        active = SimpleNamespace(
+            id="a" * 32, title="Active",
+            deleted_time=dt_module.datetime(1970, 1, 1, 0, 0),
+            parent_id="b" * 32, is_todo=0,
+        )
+        mock_client.get_all_notes.return_value = [active]
+        mock_client.get_all_notebooks.return_value = []
+        mock_get_client.return_value = mock_client
+
+        result = await list_trash.fn()
+
+        assert "TRASH_ITEMS: 0" in result
+        assert "empty" in result.lower()
+
+
+class TestRestoreFromTrashTool:
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.trash.get_joplin_client")
+    async def test_restore_note(self, mock_get_client):
+        from joplin_mcp.tools.trash import restore_from_trash
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        result = await restore_from_trash.fn(NOTE_ID, item_type="note")
+
+        mock_client.modify_note.assert_called_once_with(NOTE_ID, deleted_time=0)
+        assert "RESTORE_FROM_TRASH" in result
+        assert "SUCCESS" in result
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.trash.get_joplin_client")
+    async def test_restore_notebook(self, mock_get_client):
+        from joplin_mcp.tools.trash import restore_from_trash
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        result = await restore_from_trash.fn(NOTEBOOK_ID, item_type="notebook")
+
+        mock_client.modify_notebook.assert_called_once_with(NOTEBOOK_ID, deleted_time=0)
+        assert "notebook" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_invalid_type(self):
+        from joplin_mcp.tools.trash import restore_from_trash
+
+        with pytest.raises(ValueError, match="must be"):
+            await restore_from_trash.fn(NOTE_ID, item_type="tag")
+
+
+class TestGetNoteHistoryTool:
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes_revisions.format_timestamp", return_value="2026-03-27 15:30")
+    @patch("joplin_mcp.tools.notes_revisions.get_joplin_client")
+    async def test_shows_revisions(self, mock_get_client, mock_fmt_ts):
+        from joplin_mcp.tools.notes_revisions import get_note_history
+
+        rev1 = SimpleNamespace(
+            id="r" * 32, item_id=NOTE_ID, item_type=1,
+            item_updated_time=1700000000000,
+            parent_id="", created_time=1700000000000,
+            title_diff="", metadata_diff='{"new":{"title":"Test"},"deleted":[]}',
+        )
+        mock_client = MagicMock()
+        mock_client.get_all_revisions.return_value = [rev1]
+        mock_client.get_note.return_value = SimpleNamespace(id=NOTE_ID, title="Current Title")
+        mock_get_client.return_value = mock_client
+
+        result = await get_note_history.fn(NOTE_ID)
+
+        assert "REVISIONS: 1" in result
+        assert "r" * 32 in result
+        assert "no (first revision)" in result
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes_revisions.get_joplin_client")
+    async def test_no_revisions(self, mock_get_client):
+        from joplin_mcp.tools.notes_revisions import get_note_history
+
+        mock_client = MagicMock()
+        mock_client.get_all_revisions.return_value = []
+        mock_get_client.return_value = mock_client
+
+        result = await get_note_history.fn(NOTE_ID)
+
+        assert "REVISIONS: 0" in result
+
+
+class TestRestoreNoteRevisionTool:
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes_revisions.get_notebook_id_by_name")
+    @patch("joplin_mcp.tools.notes_revisions._reconstruct_revision_content")
+    @patch("joplin_mcp.tools.notes_revisions.get_joplin_client")
+    async def test_restores_to_new_note(self, mock_get_client, mock_reconstruct, mock_get_nb):
+        from joplin_mcp.tools.notes_revisions import restore_note_revision
+
+        mock_client = MagicMock()
+        mock_client.add_note.return_value = "new_" + "n" * 28
+        mock_client.get_notebook.return_value = SimpleNamespace(
+            id=NOTEBOOK_ID, title="Original NB", deleted_time=0,
+        )
+        mock_get_client.return_value = mock_client
+        mock_reconstruct.return_value = {
+            "title": "Restored Title",
+            "body": "Restored body content",
+            "metadata": {"parent_id": NOTEBOOK_ID},
+        }
+
+        result = await restore_note_revision.fn("r" * 32, target_notebook="Testing")
+
+        assert "RESTORE_NOTE_REVISION" in result
+        assert "SUCCESS" in result
+        assert "Restored Title" in result
+        mock_client.add_note.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes_revisions._reconstruct_revision_content")
+    @patch("joplin_mcp.tools.notes_revisions.get_joplin_client")
+    async def test_falls_back_to_restored_notes(self, mock_get_client, mock_reconstruct):
+        from joplin_mcp.tools.notes_revisions import restore_note_revision
+
+        mock_client = MagicMock()
+        mock_client.add_note.return_value = "new_" + "n" * 28
+        # Original notebook is trashed
+        mock_client.get_notebook.return_value = SimpleNamespace(
+            id=NOTEBOOK_ID, title="Trashed NB",
+            deleted_time=1700000000000,  # non-zero = trashed
+        )
+        mock_get_client.return_value = mock_client
+        mock_reconstruct.return_value = {
+            "title": "Old Title",
+            "body": "Old body",
+            "metadata": {"parent_id": NOTEBOOK_ID},
+        }
+
+        result = await restore_note_revision.fn("r" * 32)
+
+        assert "SUCCESS" in result
+        # Should fall back since original notebook is trashed
+        call_kwargs = mock_client.add_note.call_args[1]
+        assert call_kwargs["title"] == "Old Title"
+
+
+class TestBackupDatabaseTool:
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.backup_database.backup_joplin_database")
+    @patch("joplin_mcp.tools.backup_database._get_joplin_db_path")
+    async def test_success(self, mock_db_path, mock_backup):
+        from pathlib import Path
+        import tempfile
+        from joplin_mcp.tools.backup_database import backup_database
+
+        with tempfile.NamedTemporaryFile(suffix=".sqlite") as tmp:
+            mock_db_path.return_value = Path(tmp.name)
+            mock_backup.return_value = tmp.name
+            # Write some bytes so stat().st_size works
+            tmp.write(b"x" * 1024)
+            tmp.flush()
+
+            result = await backup_database.fn()
+
+        assert "BACKUP_DATABASE" in result
+        assert "SUCCESS" in result
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.backup_database.backup_joplin_database")
+    @patch("joplin_mcp.tools.backup_database._get_joplin_db_path")
+    async def test_failure(self, mock_db_path, mock_backup):
+        from pathlib import Path
+        from joplin_mcp.tools.backup_database import backup_database
+
+        mock_db_path.return_value = Path("/nonexistent/database.sqlite")
+        mock_backup.return_value = None
+
+        result = await backup_database.fn()
+
+        assert "FAILED" in result

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -973,7 +973,7 @@ class TestConfigToolConfiguration:
         enabled_tools = config.get_enabled_tools()
         disabled_tools = config.get_disabled_tools()
         assert len(enabled_tools) + len(disabled_tools) == len(config.DEFAULT_TOOLS)
-        assert len(enabled_tools) == 17
+        assert len(enabled_tools) == 29
         assert len(disabled_tools) == 7
 
         # Check specific tools

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -122,27 +122,27 @@ class TestFormatDeleteSuccess:
     """Tests for format_delete_success function."""
 
     def test_note_delete_success(self):
-        """Should format note delete success correctly."""
+        """Should format note soft-delete success correctly (default)."""
         result = format_delete_success(ItemType.note, "deleted_note_id")
-        assert "OPERATION: DELETE_NOTE" in result
+        assert "OPERATION: SOFT_DELETE_NOTE" in result
         assert "STATUS: SUCCESS" in result
         assert "ITEM_TYPE: note" in result
         assert "ITEM_ID: deleted_note_id" in result
-        assert "note deleted successfully" in result
+        assert "moved to trash" in result
 
     def test_notebook_delete_success(self):
-        """Should format notebook delete success correctly."""
+        """Should format notebook soft-delete success correctly (default)."""
         result = format_delete_success(ItemType.notebook, "nb_to_delete")
-        assert "OPERATION: DELETE_NOTEBOOK" in result
+        assert "OPERATION: SOFT_DELETE_NOTEBOOK" in result
         assert "ITEM_TYPE: notebook" in result
-        assert "notebook deleted successfully" in result
+        assert "moved to trash" in result
 
     def test_tag_delete_success(self):
-        """Should format tag delete success correctly."""
-        result = format_delete_success(ItemType.tag, "tag_gone")
+        """Should format tag permanent delete success correctly."""
+        result = format_delete_success(ItemType.tag, "tag_gone", soft_delete=False)
         assert "OPERATION: DELETE_TAG" in result
         assert "ITEM_TYPE: tag" in result
-        assert "tag deleted successfully" in result
+        assert "deleted permanently" in result
 
 
 # === Tests for format_relation_success ===


### PR DESCRIPTION
## Summary

12 new MCP tools across 7 new modules, plus supporting infrastructure. Adds bulk note/tag operations, trash management, revision history browsing and restore, and SQLite database backup — all with built-in safety mechanisms.

The overall design goal is to make it safe to ask an AI agent to completely reorganize notes across topics, notebooks, or an entire database, walk away, and know that catastrophic failures can be recovered at multiple levels — per-note revision snapshots, plus full database backup as a backstop.

Structured as 3 commits for easy review:
1. **New files only** (3,100 lines) — all our tools, helpers, and 87 unit tests. Zero changes to existing code.
2. **Required wiring** (58 lines) — dependency, imports, config entries.
3. **Optional enhancements** (56 lines) — auto-backup on update_note/edit_note, soft-delete formatting, docstring updates. Accept or reject independently.

## New Tools

**Bulk operations** (`tools/notes_bulk.py`, `tools/tags_bulk.py`):
- `move_note` — move a note to a different notebook by name or ID
- `bulk_move_notes` — move multiple notes with auto database backup
- `search_and_bulk_update_preview` — preview what a bulk update would change
- `search_and_bulk_update_execute` — execute bulk update with safety verification (count + title match from preview)
- `bulk_tag_notes` — add one or more tags to a list of notes (additive only — does not remove existing tags)
- `strip_note_tags` — remove all tags from a note

**Trash management** (`tools/trash.py`):
- `list_trash` — list soft-deleted notes/notebooks with deletion date and original notebook
- `restore_from_trash` — restore items by setting deleted_time to 0

**Revision history** (`tools/notes_revisions.py`):
- `get_note_history` — list all revisions for a note with timestamps and parent chain
- `restore_note_revision` — reconstruct content from diff chain, create as new note in the original notebook (falls back to "Restored Notes" if original is trashed)
- `manually_backup_note` — create on-demand revision snapshot

**Database backup** (`tools/backup_database.py`):
- `backup_database` — SQLite snapshot via `sqlite3 .backup`, last 10 auto-backups retained, manual backups never auto-deleted. Currently backup-only — no automated restore/swap feature; intended as a backstop for catastrophic failures.

## Safety Features

- **Preview/confirm flow**: `search_and_bulk_update_preview` → `search_and_bulk_update_execute` with count + first-title verification
- **Auto database backup**: bulk operations trigger SQLite backup before proceeding (configurable per-call: `daily`/`force`/`suppress`). Backup-only — no automated restore; intended as a backstop for catastrophic failures.
- **Per-note revision snapshots**: `save_note_revision` before title/body overwrites, following Joplin's `createNoteRevision_` algorithm with sequential diffs and parent chaining
- **All tools gated by config**: entries in `DEFAULT_TOOLS` / `TOOL_CATEGORIES` for user control

## Supporting Infrastructure

- `revision_utils.py` — diff-match-patch based revision creation and reconstruction for `restore_note_revision`
- `tools/field_helpers.py` — field registry (`JOPLIN_NOTE_FIELDS`), type converters, `_search_notes` (unified search + post-fetch AND filtering since Joplin's API can't do arbitrary WHERE clauses), `_parse_update_params`
- Note: `_search_notes` could serve as a shared internal for `find_notes` if you're interested — we deliberately didn't modify `find_notes` but designed the API to be compatible. Also, `list_trash` queries with `include_deleted=1` which `find_notes` doesn't currently expose.

## New Dependency

- `diff-match-patch>=20230430` — for revision creation/reconstruction in `restore_note_revision`

## Optional Enhancements (commit 3)

- `update_note`: auto-backup to new note revision before title/body overwrites; `convert_todo_completed` accepts bool, epoch milliseconds, or ISO datetime strings and converts to proper Joplin epoch-ms format
- `edit_note`: auto-backup to new note revision before body modifications
- `format_delete_success`: `soft_delete` param (default=True since Joplin default is soft-delete)
- `delete_note`/`delete_notebook` docstrings updated for soft-delete semantics
- `delete_tag`: explicit `soft_delete=False` (tags are permanently deleted)

## Test Plan

- [x] 87 unit tests with mocked Joplin client (`tests/pr_tests.py`)
- [x] 370 existing tests still pass (0 regressions)
- [x] Live MCP testing against Joplin Desktop 3.5.13: all 12 tools verified
- [x] Database integrity verified: no unintended modifications to user data

Happy to restructure if you prefer a different organization.
