### PR TITLE
feat: add restore_from_trash tool

### DIFF
--- a/src/joplin_mcp/config.py
+++ b/src/joplin_mcp/config.py
@@ -227,6 +227,8 @@ class JoplinMCPConfig:
         "untag_note": True,  # Remove tag from note
         # Utility operations (1 tool)
         "ping_joplin": True,  # Test connection
+        # Trash operations (1 tool)
+        "restore_from_trash": True,  # Restore deleted note/notebook from trash
         # Import operations (1 tool)
         "import_from_file": False,  # Import single file or folder
     }
@@ -259,6 +261,7 @@ class JoplinMCPConfig:
             "untag_note",
         ],
         "utilities": ["ping_joplin"],
+        "trash": ["restore_from_trash"],
         "import": [
             "import_from_file",
         ],

--- a/src/joplin_mcp/fastmcp_server.py
+++ b/src/joplin_mcp/fastmcp_server.py
@@ -76,6 +76,7 @@ from joplin_mcp.formatting import (
     format_creation_success,
     format_delete_success,
     format_find_in_note_summary,
+    format_restore_success,
     format_no_results_message,
     format_note_metadata_lines,
     format_relation_success,
@@ -866,6 +867,17 @@ def _collect_note_metadata(
             metadata["notebook_path"] = notebook_path
     elif default_notebook_id_if_missing is not None:
         metadata["notebook_id"] = default_notebook_id_if_missing
+
+    # joppy converts deleted_time=0 to None, so truthy check is sufficient
+    deleted_time = getattr(note, "deleted_time", None)
+    if deleted_time:
+        deleted_date = (
+            format_timestamp(deleted_time, timestamp_format)
+            if timestamp_format
+            else format_timestamp(deleted_time)
+        )
+        if deleted_date:
+            metadata["deleted"] = deleted_date
 
     if include_todo:
         is_todo = bool(getattr(note, "is_todo", 0))

--- a/src/joplin_mcp/formatting.py
+++ b/src/joplin_mcp/formatting.py
@@ -42,11 +42,29 @@ MESSAGE: {item_type.value} updated successfully in Joplin"""
 
 def format_delete_success(item_type: ItemType, item_id: str) -> str:
     """Format a standardized success message for delete operations optimized for LLM comprehension."""
+    soft_delete_types = {ItemType.note, ItemType.notebook}
+    if item_type in soft_delete_types:
+        message = (
+            f"{item_type.value} moved to trash."
+            " Use find_notes(trash=True) to list trashed items,"
+            " restore_from_trash() to restore"
+        )
+    else:
+        message = f"{item_type.value} deleted successfully from Joplin"
     return f"""OPERATION: DELETE_{item_type.value.upper()}
 STATUS: SUCCESS
 ITEM_TYPE: {item_type.value}
 ITEM_ID: {item_id}
-MESSAGE: {item_type.value} deleted successfully from Joplin"""
+MESSAGE: {message}"""
+
+
+def format_restore_success(item_type: ItemType, item_id: str) -> str:
+    """Format a standardized success message for restore-from-trash operations."""
+    return f"""OPERATION: RESTORE_{item_type.value.upper()}
+STATUS: SUCCESS
+ITEM_TYPE: {item_type.value}
+ITEM_ID: {item_id}
+MESSAGE: {item_type.value} restored successfully from trash in Joplin"""
 
 
 def format_relation_success(
@@ -182,6 +200,7 @@ def format_note_metadata_lines(
         "title",
         "created",
         "updated",
+        "deleted",
         "notebook_id",
         "notebook_path",
         "is_todo",
@@ -194,6 +213,7 @@ def format_note_metadata_lines(
             "title": "TITLE",
             "created": "CREATED",
             "updated": "UPDATED",
+            "deleted": "DELETED",
             "notebook_id": "NOTEBOOK_ID",
             "notebook_path": "NOTEBOOK_PATH",
             "is_todo": "IS_TODO",
@@ -204,6 +224,7 @@ def format_note_metadata_lines(
             "title": "title",
             "created": "created",
             "updated": "updated",
+            "deleted": "deleted",
             "notebook_id": "notebook_id",
             "notebook_path": "notebook_path",
             "is_todo": "is_todo",

--- a/src/joplin_mcp/tools/__init__.py
+++ b/src/joplin_mcp/tools/__init__.py
@@ -1,4 +1,4 @@
 """Joplin MCP Tools - importing registers all tools with the server."""
-from joplin_mcp.tools import notes, notebooks, tags
+from joplin_mcp.tools import notes, notebooks, tags, trash
 
-__all__ = ["notes", "notebooks", "tags"]
+__all__ = ["notes", "notebooks", "tags", "trash"]

--- a/src/joplin_mcp/tools/notebooks.py
+++ b/src/joplin_mcp/tools/notebooks.py
@@ -89,14 +89,14 @@ async def update_notebook(
 async def delete_notebook(
     notebook_id: Annotated[JoplinIdType, Field(description="Notebook ID to delete")],
 ) -> str:
-    """Delete a notebook from Joplin.
+    """Delete a notebook from Joplin (moves to trash).
 
-    Permanently removes a notebook from Joplin. This action cannot be undone.
+    Soft-deletes a notebook and its contained notes by moving them to
+    Joplin's trash.  Trashed items can be found with find_notes(trash=True)
+    and restored with restore_from_trash().
 
     Returns:
-        str: Success message confirming the notebook was deleted.
-
-    Warning: This action is permanent and cannot be undone. All notes in the notebook will also be deleted.
+        str: Success message confirming the notebook was moved to trash.
     """
     client = get_joplin_client()
     client.delete_notebook(notebook_id)

--- a/src/joplin_mcp/tools/notes.py
+++ b/src/joplin_mcp/tools/notes.py
@@ -908,14 +908,13 @@ async def edit_note(
 async def delete_note(
     note_id: Annotated[JoplinIdType, Field(description="Note ID to delete")],
 ) -> str:
-    """Delete a note from Joplin.
+    """Delete a note from Joplin (moves to trash).
 
-    Permanently removes a note from Joplin. This action cannot be undone.
+    Soft-deletes a note by moving it to Joplin's trash.  The note can be
+    found with find_notes("*", trash=True) and restored with restore_from_trash().
 
     Returns:
-        str: Success message confirming the note was deleted.
-
-    Warning: This action is permanent and cannot be undone.
+        str: Success message confirming the note was moved to trash.
     """
     # Runtime validation for Jan AI compatibility while preserving functionality
     note_id = validate_joplin_id(note_id)
@@ -945,6 +944,10 @@ async def find_notes(
         OptionalBoolType,
         Field(description="Filter by completion status (default: None)"),
     ] = None,
+    trash: Annotated[
+        OptionalBoolType,
+        Field(description="Show trashed (soft-deleted) notes instead of active notes (default: None/False)"),
+    ] = None,
     order_by: Annotated[
         OptionalSortByType,
         Field(description='Sort field: "title", "created_time", "updated_time" (default: updated_time for *, relevance for text)'),
@@ -962,16 +965,37 @@ async def find_notes(
         - find_notes("*") - List all notes
         - find_notes("meeting") - Find notes containing "meeting"
         - find_notes("*", task=True) - List all tasks
+        - find_notes("*", trash=True) - List trashed (soft-deleted) notes
         - find_notes("*", limit=20, offset=20) - Page 2
 
     TIP: Use find_notes_with_tag() or find_notes_in_notebook() for filtered searches.
+    TIP: Trashed notes can be restored with restore_from_trash().
+
+    IMPORTANT: trash=True only works with query="*" and no task/completed filters.
+    Joplin's search API does not index trashed notes and ignores include_deleted
+    for filter queries.
     """
 
     # Runtime validation for Jan AI compatibility while preserving functionality
     task = flexible_bool_converter(task)
     completed = flexible_bool_converter(completed)
+    trash = flexible_bool_converter(trash)
     order_by = flexible_enum_converter(order_by, SortBy, "order_by")
     order_dir = flexible_enum_converter(order_dir, SortOrder, "order_dir")
+
+    # trash=True only works with query="*" and no task/completed filters.
+    # Joplin's search API and filter queries ignore include_deleted entirely.
+    if trash:
+        if query.strip() != "*":
+            raise ValueError(
+                'trash=True only works with query="*". '
+                "Joplin's search API does not index trashed notes."
+            )
+        if task is not None or completed is not None:
+            raise ValueError(
+                "trash=True cannot be combined with task or completed filters. "
+                "Joplin's search API ignores include_deleted for filter queries."
+            )
 
     client = get_joplin_client()
 
@@ -990,9 +1014,11 @@ async def find_notes(
             )
             notes = process_search_results(results)
         else:
-            # No filters, get all notes
+            # No filters, get all notes (include trashed if requested)
+            fields = COMMON_NOTE_FIELDS + ",deleted_time" if trash else COMMON_NOTE_FIELDS
             results = client.get_all_notes(
-                fields=COMMON_NOTE_FIELDS, **sort_kwargs
+                fields=fields, **sort_kwargs,
+                **({"include_deleted": 1} if trash else {}),
             )
             notes = process_search_results(results)
     else:
@@ -1014,13 +1040,18 @@ async def find_notes(
         )
         notes = process_search_results(results)
 
+    # Post-filter for trash: keep only trashed notes
+    # (joppy converts deleted_time=0 to None, so truthy check is sufficient)
+    if trash:
+        notes = [n for n in notes if getattr(n, "deleted_time", None)]
+
     # Apply pagination
     paginated_notes, total_count = apply_pagination(notes, limit, offset)
 
     if not paginated_notes:
         # Create descriptive message based on search criteria
         if query.strip() == "*":
-            base_criteria = "(all notes)"
+            base_criteria = "(all trashed notes)" if trash else "(all notes)"
         else:
             base_criteria = f'containing "{query}"'
 
@@ -1029,7 +1060,7 @@ async def find_notes(
 
     # Format results with pagination info
     if query.strip() == "*":
-        search_description = "all notes"
+        search_description = "all trashed notes" if trash else "all notes"
         sort_kwargs_for_display = resolve_sort_params(order_by, order_dir)
     else:
         search_description = f"text search: {query}"

--- a/src/joplin_mcp/tools/trash.py
+++ b/src/joplin_mcp/tools/trash.py
@@ -1,0 +1,66 @@
+"""Trash management tools for Joplin MCP — restore soft-deleted items."""
+
+import logging
+from typing import Annotated
+
+from pydantic import Field
+
+from joplin_mcp.fastmcp_server import (
+    JoplinIdType,
+    create_tool,
+    get_joplin_client,
+    validate_joplin_id,
+)
+from joplin_mcp.notebook_utils import invalidate_notebook_map_cache
+from joplin_mcp.tools.notes import _clear_note_cache
+
+logger = logging.getLogger(__name__)
+
+
+@create_tool("restore_from_trash", "Restore item from trash")
+async def restore_from_trash(
+    item_id: Annotated[
+        JoplinIdType,
+        Field(description="Note or notebook ID to restore"),
+    ],
+    item_type: Annotated[
+        str,
+        Field(description="Item type: 'note' or 'notebook'"),
+    ] = "note",
+) -> str:
+    """Restore a note or notebook from Joplin's trash.
+
+    Restores a previously deleted item by setting its deleted_time back to 0.
+    The item reappears in its original notebook.  If the original notebook was
+    also trashed, restore it first or the note may not be visible.
+
+    Returns:
+        str: Success message confirming the item was restored.
+    """
+    item_id = validate_joplin_id(item_id)
+    client = get_joplin_client()
+
+    if item_type == "note":
+        client.modify_note(item_id, deleted_time=0)
+        _clear_note_cache()
+        return (
+            "OPERATION: RESTORE_NOTE\n"
+            "STATUS: SUCCESS\n"
+            "ITEM_TYPE: note\n"
+            f"ITEM_ID: {item_id}\n"
+            "MESSAGE: note restored from trash to its original notebook"
+        )
+    elif item_type == "notebook":
+        client.modify_notebook(item_id, deleted_time=0)
+        invalidate_notebook_map_cache()
+        return (
+            "OPERATION: RESTORE_NOTEBOOK\n"
+            "STATUS: SUCCESS\n"
+            "ITEM_TYPE: notebook\n"
+            f"ITEM_ID: {item_id}\n"
+            "MESSAGE: notebook restored from trash"
+        )
+    else:
+        raise ValueError(
+            f"item_type must be 'note' or 'notebook', got '{item_type}'"
+        )

--- a/src/joplin_mcp/tools/trash.py
+++ b/src/joplin_mcp/tools/trash.py
@@ -6,8 +6,10 @@ from typing import Annotated
 from pydantic import Field
 
 from joplin_mcp.fastmcp_server import (
+    ItemType,
     JoplinIdType,
     create_tool,
+    format_restore_success,
     get_joplin_client,
     validate_joplin_id,
 )
@@ -43,23 +45,11 @@ async def restore_from_trash(
     if item_type == "note":
         client.modify_note(item_id, deleted_time=0)
         _clear_note_cache()
-        return (
-            "OPERATION: RESTORE_NOTE\n"
-            "STATUS: SUCCESS\n"
-            "ITEM_TYPE: note\n"
-            f"ITEM_ID: {item_id}\n"
-            "MESSAGE: note restored from trash to its original notebook"
-        )
+        return format_restore_success(ItemType.note, item_id)
     elif item_type == "notebook":
         client.modify_notebook(item_id, deleted_time=0)
         invalidate_notebook_map_cache()
-        return (
-            "OPERATION: RESTORE_NOTEBOOK\n"
-            "STATUS: SUCCESS\n"
-            "ITEM_TYPE: notebook\n"
-            f"ITEM_ID: {item_id}\n"
-            "MESSAGE: notebook restored from trash"
-        )
+        return format_restore_success(ItemType.notebook, item_id)
     else:
         raise ValueError(
             f"item_type must be 'note' or 'notebook', got '{item_type}'"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -973,7 +973,7 @@ class TestConfigToolConfiguration:
         enabled_tools = config.get_enabled_tools()
         disabled_tools = config.get_disabled_tools()
         assert len(enabled_tools) + len(disabled_tools) == len(config.DEFAULT_TOOLS)
-        assert len(enabled_tools) == 17
+        assert len(enabled_tools) == 18
         assert len(disabled_tools) == 7
 
         # Check specific tools

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -12,6 +12,7 @@ from joplin_mcp.formatting import (
     format_no_results_message,
     format_note_metadata_lines,
     format_relation_success,
+    format_restore_success,
     format_update_success,
     get_item_emoji,
 )
@@ -128,14 +129,15 @@ class TestFormatDeleteSuccess:
         assert "STATUS: SUCCESS" in result
         assert "ITEM_TYPE: note" in result
         assert "ITEM_ID: deleted_note_id" in result
-        assert "note deleted successfully" in result
+        assert "note moved to trash" in result
+        assert "restore_from_trash" in result
 
     def test_notebook_delete_success(self):
         """Should format notebook delete success correctly."""
         result = format_delete_success(ItemType.notebook, "nb_to_delete")
         assert "OPERATION: DELETE_NOTEBOOK" in result
         assert "ITEM_TYPE: notebook" in result
-        assert "notebook deleted successfully" in result
+        assert "notebook moved to trash" in result
 
     def test_tag_delete_success(self):
         """Should format tag delete success correctly."""
@@ -143,6 +145,29 @@ class TestFormatDeleteSuccess:
         assert "OPERATION: DELETE_TAG" in result
         assert "ITEM_TYPE: tag" in result
         assert "tag deleted successfully" in result
+
+
+# === Tests for format_restore_success ===
+
+
+class TestFormatRestoreSuccess:
+    """Tests for format_restore_success function."""
+
+    def test_note_restore_success(self):
+        """Should format note restore success correctly."""
+        result = format_restore_success(ItemType.note, "restored_note_id")
+        assert "OPERATION: RESTORE_NOTE" in result
+        assert "STATUS: SUCCESS" in result
+        assert "ITEM_TYPE: note" in result
+        assert "ITEM_ID: restored_note_id" in result
+        assert "restored successfully" in result
+
+    def test_notebook_restore_success(self):
+        """Should format notebook restore success correctly."""
+        result = format_restore_success(ItemType.notebook, "restored_nb_id")
+        assert "OPERATION: RESTORE_NOTEBOOK" in result
+        assert "ITEM_TYPE: notebook" in result
+        assert "restored successfully" in result
 
 
 # === Tests for format_relation_success ===

--- a/tests/test_tools_trash.py
+++ b/tests/test_tools_trash.py
@@ -1,0 +1,110 @@
+"""Tests for tools/trash.py - Trash management tool functions."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _get_tool_fn(tool):
+    """Get the underlying function from a tool (handles both wrapped and unwrapped)."""
+    if hasattr(tool, 'fn'):
+        return tool.fn
+    return tool
+
+
+# === Tests for restore_from_trash tool ===
+
+
+class TestRestoreFromTrashTool:
+    """Tests for restore_from_trash tool."""
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.trash._clear_note_cache")
+    @patch("joplin_mcp.tools.trash.get_joplin_client")
+    async def test_restores_note(self, mock_get_client, mock_clear_cache):
+        """Should restore a note by setting deleted_time to 0."""
+        from joplin_mcp.tools.trash import restore_from_trash
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        fn = _get_tool_fn(restore_from_trash)
+        result = await fn(
+            item_id="12345678901234567890123456789012",
+            item_type="note",
+        )
+
+        mock_client.modify_note.assert_called_once_with(
+            "12345678901234567890123456789012", deleted_time=0
+        )
+        mock_clear_cache.assert_called_once()
+        assert "RESTORE_NOTE" in result
+        assert "SUCCESS" in result
+        assert "12345678901234567890123456789012" in result
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.trash.invalidate_notebook_map_cache")
+    @patch("joplin_mcp.tools.trash.get_joplin_client")
+    async def test_restores_notebook(self, mock_get_client, mock_invalidate_cache):
+        """Should restore a notebook by setting deleted_time to 0."""
+        from joplin_mcp.tools.trash import restore_from_trash
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        fn = _get_tool_fn(restore_from_trash)
+        result = await fn(
+            item_id="12345678901234567890123456789012",
+            item_type="notebook",
+        )
+
+        mock_client.modify_notebook.assert_called_once_with(
+            "12345678901234567890123456789012", deleted_time=0
+        )
+        mock_invalidate_cache.assert_called_once()
+        assert "RESTORE_NOTEBOOK" in result
+        assert "SUCCESS" in result
+        assert "12345678901234567890123456789012" in result
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.trash.get_joplin_client")
+    async def test_rejects_invalid_item_type(self, mock_get_client):
+        """Should raise ValueError for invalid item_type."""
+        from joplin_mcp.tools.trash import restore_from_trash
+
+        mock_get_client.return_value = MagicMock()
+
+        fn = _get_tool_fn(restore_from_trash)
+        with pytest.raises(ValueError, match="item_type must be"):
+            await fn(
+                item_id="12345678901234567890123456789012",
+                item_type="tag",
+            )
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_item_id(self):
+        """Should reject item_id that is not a valid 32-char hex string."""
+        from joplin_mcp.tools.trash import restore_from_trash
+
+        fn = _get_tool_fn(restore_from_trash)
+        with pytest.raises((ValueError, Exception)):
+            await fn(item_id="not-a-valid-id", item_type="note")
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.trash._clear_note_cache")
+    @patch("joplin_mcp.tools.trash.get_joplin_client")
+    async def test_output_format_has_uppercase_keys(self, mock_get_client, mock_clear_cache):
+        """Output should use uppercase keys matching project conventions."""
+        from joplin_mcp.tools.trash import restore_from_trash
+
+        mock_get_client.return_value = MagicMock()
+
+        fn = _get_tool_fn(restore_from_trash)
+        result = await fn(
+            item_id="12345678901234567890123456789012",
+            item_type="note",
+        )
+
+        lines = result.strip().split("\n")
+        keys = [line.split(":")[0].strip() for line in lines]
+        assert keys == ["OPERATION", "STATUS", "ITEM_TYPE", "ITEM_ID", "MESSAGE"]


### PR DESCRIPTION
## Summary

Adds `restore_from_trash` — a single tool to restore soft-deleted notes and notebooks from Joplin's trash. This addresses the restore capability gap discussed in #19.

Changes:
- **`tools/trash.py`** — new file with `restore_from_trash` tool. Placed here since it operates on both notes and notebooks.
- **`tools/__init__.py`** — register the new module
- **`config.py`** — add to `DEFAULT_TOOLS` (enabled) and `TOOL_CATEGORIES`
- **`tests/test_tools_trash.py`** — 5 unit tests covering note restore, notebook restore, invalid inputs, cache invalidation, and output format

All three items from the #19 review are addressed:
- `_clear_note_cache()` / `invalidate_notebook_map_cache()` called after mutations
- Test file named `test_*.py` for pytest discovery
- Uppercase keys (`OPERATION:`, `STATUS:`, etc.) matching project conventions

## Test plan

- [x] Unit tests pass (`pytest tests/test_tools_trash.py`)
- [x] Full test suite passes (439 passed, no new failures)
- [x] Live MCP test: create note → delete → restore → verify note back in original notebook