### PR TITLE
feat: enforce notebook allowlist across all tools

### DIFF
--- a/src/joplin_mcp/fastmcp_server.py
+++ b/src/joplin_mcp/fastmcp_server.py
@@ -1233,8 +1233,9 @@ def main(
         client = get_joplin_client()
         logger.info("Joplin client initialized successfully")
 
-        # Validate notebook allowlist and warm caches at startup
-        validate_allowlist_at_startup(_config, client)
+        # Validate and log notebook allowlist at startup (D3, D6, D9)
+        runtime_config = _config or _module_config
+        validate_allowlist_at_startup(runtime_config, client)
 
         # ---- Non-breaking compat toggle via env ----
         compat_env = os.getenv("MCP_HTTP_COMPAT", "").strip().lower() in {"1","true","yes","on"}

--- a/src/joplin_mcp/fastmcp_server.py
+++ b/src/joplin_mcp/fastmcp_server.py
@@ -1221,6 +1221,12 @@ def main(
         if config_file:
             _config = JoplinMCPConfig.from_file(config_file)
             logger.info(f"Runtime configuration loaded from {config_file}")
+            # Tools read _module_config directly via `from ... import _module_config`
+            # and hold a reference to the original object. Mutate that object's
+            # allowlist in place so runtime config and tool enforcement stay aligned;
+            # otherwise the startup log would reflect the runtime config while the
+            # tools still enforce the auto-discovered module-level one.
+            _module_config.notebook_allowlist = _config.notebook_allowlist
         else:
             _config = _module_config
             logger.info("Using module-level configuration for runtime")

--- a/src/joplin_mcp/fastmcp_server.py
+++ b/src/joplin_mcp/fastmcp_server.py
@@ -533,12 +533,16 @@ def _get_item_id_by_name(
     fields: str,
     not_found_hint: str = "",
 ) -> str:
-    """Generic helper to find notebook/tag ID by name with helpful error messages.
+    """Generic helper to find an item ID by name with helpful error messages.
+
+    Notebook lookups go through get_notebook_id_by_name which walks the
+    allowlist-filtered cache directly; this helper is used for tag lookups
+    (and any future item type that doesn't need allowlist filtering).
 
     Args:
         name: The item name to search for
-        item_type: Type of item for error messages (e.g., "notebook", "tag")
-        fetch_fn: Function to fetch all items (e.g., client.get_all_notebooks)
+        item_type: Type of item for error messages (e.g., "tag")
+        fetch_fn: Function to fetch all items (e.g., client.get_all_tags)
         fields: Fields to request from the API
         not_found_hint: Optional hint to append to "not found" error message
 
@@ -562,28 +566,14 @@ def _get_item_id_by_name(
         )
 
     if len(matching_items) > 1:
-        if item_type == "notebook":
-            # Show full paths for notebooks to help disambiguation
-            notebooks_map = get_notebook_map_cached()
-            item_paths = [
-                _compute_notebook_path(getattr(item, 'id', ''), notebooks_map, sep="/")
-                or getattr(item, 'title', 'Untitled')
-                for item in matching_items
-            ]
-            paths_str = ", ".join(f"'{p}'" for p in item_paths)
-            raise ValueError(
-                f"Multiple notebooks found with name '{name}'. "
-                f"Use full path to specify: {paths_str}"
-            )
-        else:
-            item_details = [
-                f"'{getattr(item, 'title', 'Untitled')}' (ID: {getattr(item, 'id', 'unknown')})"
-                for item in matching_items
-            ]
-            raise ValueError(
-                f"Multiple {item_type}s found with name '{name}': {', '.join(item_details)}. "
-                "Please be more specific."
-            )
+        item_details = [
+            f"'{getattr(item, 'title', 'Untitled')}' (ID: {getattr(item, 'id', 'unknown')})"
+            for item in matching_items
+        ]
+        raise ValueError(
+            f"Multiple {item_type}s found with name '{name}': {', '.join(item_details)}. "
+            "Please be more specific."
+        )
 
     item_id = getattr(matching_items[0], "id", None)
     if not item_id:

--- a/src/joplin_mcp/notebook_utils.py
+++ b/src/joplin_mcp/notebook_utils.py
@@ -369,6 +369,43 @@ def validate_notebook_access(
         raise AllowlistDeniedError("Notebook not accessible")
 
 
+def get_accessible_notebook_map(
+    allowlist_entries: Optional[List[str]] = None,
+    force_refresh: bool = False,
+    client_fn: Optional[Callable] = None,
+) -> Dict[str, Dict[str, Optional[str]]]:
+    """Return the notebook map filtered by allowlist for path resolution.
+
+    When allowlist_entries is None or empty, returns the full cached map.
+    When set, returns a map containing only accessible notebooks plus their
+    ancestors. Ancestors are kept so that path resolution still works for
+    nested allowlist entries (e.g. allowlist=['Personal/Work'] requires
+    'Personal' in the map to resolve 'Personal/Work').
+
+    Shares the same TTL as get_notebook_map_cached.
+    """
+    nb_map = get_notebook_map_cached(
+        force_refresh=force_refresh, client_fn=client_fn
+    )
+    if not allowlist_entries:
+        return nb_map
+
+    positive_spec, negation_spec, hex_ids = _get_allowlist_specs(allowlist_entries)
+
+    visible: set = set()
+    for nb_id in nb_map:
+        path = _compute_notebook_path(nb_id, nb_map, sep="/")
+        if not path:
+            continue
+        if _matches_allowlist(path, nb_id, positive_spec, negation_spec, hex_ids):
+            curr = nb_id
+            while curr and curr not in visible:
+                visible.add(curr)
+                curr = (nb_map.get(curr) or {}).get("parent_id")
+
+    return {nb_id: info for nb_id, info in nb_map.items() if nb_id in visible}
+
+
 def filter_accessible_notebooks(
     notebooks: List[Any],
     allowlist_entries: List[str],
@@ -452,7 +489,18 @@ def _resolve_notebook_by_path(path: str) -> str:
     if not parts:
         raise ValueError("Empty notebook path")
 
-    notebooks_map = get_notebook_map_cached(force_refresh=True)
+    # Filter the map by allowlist when one is configured so that suggestions
+    # and partial-resolution errors can't leak the names of denied notebooks.
+    from joplin_mcp.fastmcp_server import _module_config
+
+    allowlist = (
+        _module_config.notebook_allowlist
+        if _module_config.has_notebook_allowlist
+        else None
+    )
+    notebooks_map = get_accessible_notebook_map(
+        allowlist_entries=allowlist, force_refresh=True
+    )
 
     current_parent: Optional[str] = None
     for part in parts:

--- a/src/joplin_mcp/notebook_utils.py
+++ b/src/joplin_mcp/notebook_utils.py
@@ -542,16 +542,50 @@ def get_notebook_id_by_name(name: str) -> str:
     if "/" in name:
         return _resolve_notebook_by_path(name)
 
-    # Otherwise, use flat name matching via generic helper
-    from joplin_mcp.fastmcp_server import _get_item_id_by_name, get_joplin_client
+    # Flat name: walk the allowlist-filtered map so error messages can't leak
+    # the names of denied notebooks. The generic _get_item_id_by_name helper
+    # is shared with tag lookups (tags aren't allowlist-gated), so the filter
+    # belongs at this call site rather than in the helper.
+    from joplin_mcp.fastmcp_server import _module_config
 
-    client = get_joplin_client()
-    return _get_item_id_by_name(
-        name=name,
-        item_type="notebook",
-        fetch_fn=client.get_all_notebooks,
-        fields="id,title,created_time,updated_time,parent_id",
+    allowlist = (
+        _module_config.notebook_allowlist
+        if _module_config.has_notebook_allowlist
+        else None
     )
+    notebooks_map = get_accessible_notebook_map(
+        allowlist_entries=allowlist, force_refresh=True
+    )
+
+    name_lower = name.lower()
+    matches = [
+        nb_id for nb_id, info in notebooks_map.items()
+        if (info.get("title") or "").lower() == name_lower
+    ]
+
+    if not matches:
+        suggestions = _find_notebook_suggestions(name, notebooks_map)
+        if suggestions:
+            suggestion_str = ", ".join(f"'{s}'" for s in suggestions)
+            raise ValueError(
+                f"Notebook '{name}' not found. "
+                f"Did you mean: {suggestion_str}?"
+            )
+        raise ValueError(f"Notebook '{name}' not found")
+
+    if len(matches) > 1:
+        paths = [
+            _compute_notebook_path(nb_id, notebooks_map, sep="/")
+            or (notebooks_map[nb_id].get("title") or "Untitled")
+            for nb_id in matches
+        ]
+        paths_str = ", ".join(f"'{p}'" for p in paths)
+        raise ValueError(
+            f"Multiple notebooks found with name '{name}'. "
+            f"Use full path to specify: {paths_str}"
+        )
+
+    return matches[0]
 
 
 # === STARTUP VALIDATION ===

--- a/src/joplin_mcp/tools/notebooks.py
+++ b/src/joplin_mcp/tools/notebooks.py
@@ -7,6 +7,7 @@ from joplin_mcp.fastmcp_server import (
     ItemType,
     JoplinIdType,
     RequiredStringType,
+    _module_config,
     create_tool,
     format_creation_success,
     format_delete_success,
@@ -15,7 +16,11 @@ from joplin_mcp.fastmcp_server import (
     get_joplin_client,
     invalidate_notebook_map_cache,
 )
-
+from joplin_mcp.notebook_utils import (
+    AllowlistDeniedError,
+    filter_accessible_notebooks,
+    validate_notebook_access,
+)
 
 # === NOTEBOOK TOOLS ===
 
@@ -32,6 +37,10 @@ async def list_notebooks() -> str:
     client = get_joplin_client()
     fields_list = "id,title,created_time,updated_time,parent_id"
     notebooks = client.get_all_notebooks(fields=fields_list)
+    if _module_config.has_notebook_allowlist:
+        notebooks = filter_accessible_notebooks(
+            notebooks, allowlist_entries=_module_config.notebook_allowlist
+        )
     return format_item_list(notebooks, ItemType.notebook)
 
 
@@ -54,6 +63,15 @@ async def create_notebook(
         - create_notebook("Work Projects") - Create a top-level notebook
         - create_notebook("2024 Projects", "work_notebook_id") - Create a sub-notebook
     """
+
+    if _module_config.has_notebook_allowlist:
+        if parent_id:
+            validate_notebook_access(
+                parent_id.strip(),
+                allowlist_entries=_module_config.notebook_allowlist,
+            )
+        else:
+            raise ValueError("Notebook not accessible")
 
     client = get_joplin_client()
     notebook_kwargs = {"title": title}
@@ -78,6 +96,11 @@ async def update_notebook(
     Returns:
         str: Success message confirming the notebook was updated.
     """
+    if _module_config.has_notebook_allowlist:
+        validate_notebook_access(
+            notebook_id, allowlist_entries=_module_config.notebook_allowlist
+        )
+
     client = get_joplin_client()
     client.modify_notebook(notebook_id, title=title)
     # Invalidate cache in case the notebook moved/renamed
@@ -98,6 +121,11 @@ async def delete_notebook(
     Returns:
         str: Success message confirming the notebook was moved to trash.
     """
+    if _module_config.has_notebook_allowlist:
+        validate_notebook_access(
+            notebook_id, allowlist_entries=_module_config.notebook_allowlist
+        )
+
     client = get_joplin_client()
     client.delete_notebook(notebook_id)
     # Invalidate cache since structure changed

--- a/src/joplin_mcp/tools/notebooks.py
+++ b/src/joplin_mcp/tools/notebooks.py
@@ -17,7 +17,6 @@ from joplin_mcp.fastmcp_server import (
     invalidate_notebook_map_cache,
 )
 from joplin_mcp.notebook_utils import (
-    AllowlistDeniedError,
     filter_accessible_notebooks,
     validate_notebook_access,
 )

--- a/src/joplin_mcp/tools/notes.py
+++ b/src/joplin_mcp/tools/notes.py
@@ -4,7 +4,6 @@ from typing import Annotated, Any, Dict, List, Optional, Union
 
 from pydantic import Field
 
-
 # === NOTE CACHE FOR SEQUENTIAL READING ===
 # Caches one note to avoid re-fetching when reading in chunks.
 
@@ -82,7 +81,11 @@ from joplin_mcp.formatting import (
     format_find_in_note_summary,
     format_note_metadata_lines,
 )
-
+from joplin_mcp.notebook_utils import (
+    AllowlistDeniedError,
+    is_notebook_accessible,
+    validate_notebook_access,
+)
 
 # === NOTE HELPER FUNCTIONS ===
 
@@ -429,6 +432,11 @@ async def get_note(
     else:
         note = client.get_note(note_id, fields=COMMON_NOTE_FIELDS)
 
+    # Allowlist validation: ensure note is in an accessible notebook
+    if _module_config.has_notebook_allowlist:
+        parent_id = getattr(note, 'parent_id', '')
+        validate_notebook_access(parent_id, allowlist_entries=_module_config.notebook_allowlist)
+
     # Handle line extraction first (for sequential reading)
     if start_line is not None:
         line_result = _handle_line_extraction(
@@ -489,6 +497,11 @@ async def get_links(
     # Get the note
     note = client.get_note(note_id, fields=COMMON_NOTE_FIELDS)
 
+    # Allowlist validation: ensure source note is in an accessible notebook
+    if _module_config.has_notebook_allowlist:
+        source_parent_id = getattr(note, 'parent_id', '')
+        validate_notebook_access(source_parent_id, allowlist_entries=_module_config.notebook_allowlist)
+
     note_title = getattr(note, "title", "Untitled")
     body = getattr(note, "body", "")
 
@@ -507,12 +520,22 @@ async def get_links(
 
                 # Try to get the target note title
                 try:
-                    target_note = client.get_note(target_note_id, fields="id,title")
+                    target_note = client.get_note(target_note_id, fields="id,title,parent_id")
                     target_title = getattr(target_note, "title", "Unknown Note")
                     target_exists = True
                 except Exception:
                     target_title = "Note not found"
                     target_exists = False
+                    target_note = None
+
+                # Allowlist filtering: skip linked notes in non-accessible notebooks
+                if _module_config.has_notebook_allowlist and target_note is not None:
+                    target_parent_id = getattr(target_note, 'parent_id', '')
+                    if not is_notebook_accessible(
+                        target_parent_id,
+                        allowlist_entries=_module_config.notebook_allowlist
+                    ):
+                        continue
 
                 link_data = {
                     "text": link_text,
@@ -541,6 +564,13 @@ async def get_links(
             query=search_query, fields=COMMON_NOTE_FIELDS
         )
         backlink_notes = process_search_results(backlink_results)
+
+        # Allowlist filtering: only include backlinks from accessible notebooks
+        if _module_config.has_notebook_allowlist:
+            backlink_notes = [n for n in backlink_notes if is_notebook_accessible(
+                getattr(n, 'parent_id', ''),
+                allowlist_entries=_module_config.notebook_allowlist
+            )]
 
         # Filter out the current note and parse backlinks
         for source_note in backlink_notes:
@@ -710,6 +740,10 @@ async def create_note(
     # Use helper function to get notebook ID
     parent_id = get_notebook_id_by_name(notebook_name)
 
+    # Allowlist validation: ensure target notebook is accessible
+    if _module_config.has_notebook_allowlist:
+        validate_notebook_access(parent_id, allowlist_entries=_module_config.notebook_allowlist)
+
     client = get_joplin_client()
     note_kwargs = {
         "title": title,
@@ -790,6 +824,13 @@ async def update_note(
         raise ValueError("At least one field must be provided for update")
 
     client = get_joplin_client()
+
+    # Allowlist validation: ensure note is in an accessible notebook
+    if _module_config.has_notebook_allowlist:
+        note = client.get_note(note_id, fields="id,parent_id")
+        parent_id_check = getattr(note, 'parent_id', '')
+        validate_notebook_access(parent_id_check, allowlist_entries=_module_config.notebook_allowlist)
+
     client.modify_note(note_id, **update_data)
     _clear_note_cache()
 
@@ -867,6 +908,12 @@ async def edit_note(
 
     client = get_joplin_client()
     note = client.get_note(note_id, fields=COMMON_NOTE_FIELDS)
+
+    # Allowlist validation: ensure note is in an accessible notebook
+    if _module_config.has_notebook_allowlist:
+        parent_id = getattr(note, 'parent_id', '')
+        validate_notebook_access(parent_id, allowlist_entries=_module_config.notebook_allowlist)
+
     body = getattr(note, "body", "") or ""
 
     if old_string is not None:
@@ -933,6 +980,13 @@ async def delete_note(
     note_id = validate_joplin_id(note_id)
 
     client = get_joplin_client()
+
+    # Allowlist validation: ensure note is in an accessible notebook
+    if _module_config.has_notebook_allowlist:
+        note = client.get_note(note_id, fields="id,parent_id")
+        parent_id = getattr(note, 'parent_id', '')
+        validate_notebook_access(parent_id, allowlist_entries=_module_config.notebook_allowlist)
+
     client.delete_note(note_id)
 
     # Invalidate cache for deleted note
@@ -1059,6 +1113,13 @@ async def find_notes(
     if trash:
         notes = [n for n in notes if getattr(n, "deleted_time", None)]
 
+    # Allowlist filtering: only include notes in accessible notebooks
+    if _module_config.has_notebook_allowlist:
+        notes = [n for n in notes if is_notebook_accessible(
+            getattr(n, 'parent_id', ''),
+            allowlist_entries=_module_config.notebook_allowlist
+        )]
+
     # Apply pagination
     paginated_notes, total_count = apply_pagination(notes, limit, offset)
 
@@ -1159,6 +1220,11 @@ async def find_in_note(
 
     client = get_joplin_client()
     note = client.get_note(note_id, fields=COMMON_NOTE_FIELDS)
+
+    # Allowlist validation: ensure note is in an accessible notebook
+    if _module_config.has_notebook_allowlist:
+        parent_id = getattr(note, 'parent_id', '')
+        validate_notebook_access(parent_id, allowlist_entries=_module_config.notebook_allowlist)
 
     body = getattr(note, "body", "") or ""
 
@@ -1381,6 +1447,13 @@ async def find_notes_with_tag(
     )
     notes = process_search_results(results)
 
+    # Allowlist filtering: only include notes in accessible notebooks
+    if _module_config.has_notebook_allowlist:
+        notes = [n for n in notes if is_notebook_accessible(
+            getattr(n, 'parent_id', ''),
+            allowlist_entries=_module_config.notebook_allowlist
+        )]
+
     # Apply pagination
     paginated_notes, total_count = apply_pagination(notes, limit, offset)
 
@@ -1461,6 +1534,10 @@ async def find_notes_in_notebook(
     # Resolve notebook name/path to ID (ensures exact match)
     notebook_id = get_notebook_id_by_name(notebook_name)
 
+    # Allowlist validation: ensure notebook is accessible
+    if _module_config.has_notebook_allowlist:
+        validate_notebook_access(notebook_id, allowlist_entries=_module_config.notebook_allowlist)
+
     # Fetch notes by notebook_id for precision (search API can't distinguish same-named notebooks)
     client = get_joplin_client()
     results = client.get_all_notes(
@@ -1532,6 +1609,13 @@ async def get_all_notes(
     client = get_joplin_client()
     results = client.get_all_notes(fields=COMMON_NOTE_FIELDS, **sort_kwargs)
     notes = process_search_results(results)
+
+    # Allowlist filtering: only include notes in accessible notebooks
+    if _module_config.has_notebook_allowlist:
+        notes = [n for n in notes if is_notebook_accessible(
+            getattr(n, 'parent_id', ''),
+            allowlist_entries=_module_config.notebook_allowlist
+        )]
 
     # Apply limit (using consistent pattern but keeping simple offset=0)
     notes = notes[:limit]

--- a/src/joplin_mcp/tools/notes.py
+++ b/src/joplin_mcp/tools/notes.py
@@ -82,7 +82,6 @@ from joplin_mcp.formatting import (
     format_note_metadata_lines,
 )
 from joplin_mcp.notebook_utils import (
-    AllowlistDeniedError,
     is_notebook_accessible,
     validate_notebook_access,
 )

--- a/src/joplin_mcp/tools/notes.py
+++ b/src/joplin_mcp/tools/notes.py
@@ -825,11 +825,16 @@ async def update_note(
 
     client = get_joplin_client()
 
-    # Allowlist validation: ensure note is in an accessible notebook
+    # Allowlist validation: source must be accessible, and if moving, destination too.
     if _module_config.has_notebook_allowlist:
         note = client.get_note(note_id, fields="id,parent_id")
         parent_id_check = getattr(note, 'parent_id', '')
         validate_notebook_access(parent_id_check, allowlist_entries=_module_config.notebook_allowlist)
+        if "parent_id" in update_data:
+            validate_notebook_access(
+                update_data["parent_id"],
+                allowlist_entries=_module_config.notebook_allowlist,
+            )
 
     client.modify_note(note_id, **update_data)
     _clear_note_cache()

--- a/src/joplin_mcp/tools/tags.py
+++ b/src/joplin_mcp/tools/tags.py
@@ -8,6 +8,7 @@ from joplin_mcp.fastmcp_server import (
     ItemType,
     JoplinIdType,
     RequiredStringType,
+    _module_config,
     _redact_token,
     create_tool,
     format_creation_success,
@@ -21,7 +22,7 @@ from joplin_mcp.fastmcp_server import (
     get_tag_id_by_name,
     process_search_results,
 )
-
+from joplin_mcp.notebook_utils import AllowlistDeniedError, validate_notebook_access
 
 # === TAG-NOTE BULK HELPERS ===
 
@@ -192,6 +193,15 @@ async def get_tags_by_note(
     """
 
     client = get_joplin_client()
+
+    # Allowlist validation: ensure note is in an accessible notebook
+    if _module_config.has_notebook_allowlist:
+        note = client.get_note(note_id, fields="id,parent_id")
+        parent_id = getattr(note, "parent_id", "")
+        validate_notebook_access(
+            parent_id, allowlist_entries=_module_config.notebook_allowlist
+        )
+
     fields_list = "id,title,created_time,updated_time"
     tags_result = client.get_tags(note_id=note_id, fields=fields_list)
     tags = process_search_results(tags_result)
@@ -255,6 +265,14 @@ async def tag_note(
                 f"Note with ID '{note_ids[0]}' not found. "
                 "Use find_notes to find available notes."
             )
+
+        # Allowlist validation: ensure note is in an accessible notebook
+        if _module_config.has_notebook_allowlist:
+            parent_id = getattr(note, "parent_id", "")
+            validate_notebook_access(
+                parent_id, allowlist_entries=_module_config.notebook_allowlist
+            )
+
         tag_id = get_tag_id_by_name(tag_names[0])
         client.add_tag_to_note(tag_id, note_ids[0])
         return format_relation_success(
@@ -270,6 +288,19 @@ async def tag_note(
 
     results: List[Tuple[str, str, bool, str]] = []
     for nid in note_ids:
+        # Allowlist validation per note in bulk path
+        if _module_config.has_notebook_allowlist:
+            try:
+                note = client.get_note(nid, fields="id,parent_id")
+                parent_id = getattr(note, "parent_id", "")
+                validate_notebook_access(
+                    parent_id, allowlist_entries=_module_config.notebook_allowlist
+                )
+            except AllowlistDeniedError as e:
+                for tname in tag_names:
+                    results.append((nid, tname, False, str(e)))
+                continue
+
         for tname in tag_names:
             try:
                 client.add_tag_to_note(tag_map[tname], nid)
@@ -330,6 +361,14 @@ async def untag_note(
                 f"Note with ID '{note_ids[0]}' not found. "
                 "Use find_notes to find available notes."
             )
+
+        # Allowlist validation: ensure note is in an accessible notebook
+        if _module_config.has_notebook_allowlist:
+            parent_id = getattr(note, "parent_id", "")
+            validate_notebook_access(
+                parent_id, allowlist_entries=_module_config.notebook_allowlist
+            )
+
         tag_id = get_tag_id_by_name(tag_names[0])
         client.delete(f"/tags/{tag_id}/notes/{note_ids[0]}")
         return format_relation_success(
@@ -345,6 +384,19 @@ async def untag_note(
 
     results: List[Tuple[str, str, bool, str]] = []
     for nid in note_ids:
+        # Allowlist validation per note in bulk path
+        if _module_config.has_notebook_allowlist:
+            try:
+                note = client.get_note(nid, fields="id,parent_id")
+                parent_id = getattr(note, "parent_id", "")
+                validate_notebook_access(
+                    parent_id, allowlist_entries=_module_config.notebook_allowlist
+                )
+            except AllowlistDeniedError as e:
+                for tname in tag_names:
+                    results.append((nid, tname, False, str(e)))
+                continue
+
         for tname in tag_names:
             try:
                 client.delete(f"/tags/{tag_map[tname]}/notes/{nid}")

--- a/src/joplin_mcp/tools/tags.py
+++ b/src/joplin_mcp/tools/tags.py
@@ -231,13 +231,12 @@ async def tag_note(
     Both args accept a single string or a list. When either is a list, the cartesian
     product is applied (every tag on every note) in one call — preferred over looping.
 
-    Output shape:
-    - Scalar note_id + scalar tag_name: single-op success line (unchanged).
-    - Any list input: aggregated TAG_NOTE report with TOTAL_OPS / SUCCEEDED / FAILED.
+    Output: aggregated TAG_NOTE report with TOTAL_OPS / SUCCEEDED / FAILED, one row
+    per (note, tag) pair (so the scalar case is a one-row report).
 
     Tags must exist beforehand — use create_tag to add new ones. Missing tags are
-    reported up front and nothing is applied. Per-op failures (e.g. invalid note ID)
-    are captured in the aggregated report; other ops still run.
+    reported up front and nothing is applied. Per-op failures (e.g. invalid note ID
+    or allowlist denial) are captured in the report; other ops still run.
 
     Examples:
         - tag_note("abc...", "Work") - Tag one note with one tag
@@ -245,7 +244,6 @@ async def tag_note(
         - tag_note("abc...", ["Work", "Urgent"]) - Add two tags to one note
         - tag_note(["abc...", "def..."], ["Work", "Urgent"]) - 2x2 = 4 ops
     """
-    scalar_inputs = isinstance(note_id, str) and isinstance(tag_name, str)
     note_ids = [note_id] if isinstance(note_id, str) else list(note_id)
     tag_names = [tag_name] if isinstance(tag_name, str) else list(tag_name)
     if not note_ids:
@@ -255,35 +253,7 @@ async def tag_note(
 
     client = get_joplin_client()
 
-    if scalar_inputs:
-        # Preserve existing single-op output format for backwards compatibility.
-        try:
-            note = client.get_note(note_ids[0], fields=COMMON_NOTE_FIELDS)
-            note_title = getattr(note, "title", "Unknown Note")
-        except Exception:
-            raise ValueError(
-                f"Note with ID '{note_ids[0]}' not found. "
-                "Use find_notes to find available notes."
-            )
-
-        # Allowlist validation: ensure note is in an accessible notebook
-        if _module_config.has_notebook_allowlist:
-            parent_id = getattr(note, "parent_id", "")
-            validate_notebook_access(
-                parent_id, allowlist_entries=_module_config.notebook_allowlist
-            )
-
-        tag_id = get_tag_id_by_name(tag_names[0])
-        client.add_tag_to_note(tag_id, note_ids[0])
-        return format_relation_success(
-            "tagged note",
-            ItemType.note,
-            f"{note_title} (ID: {note_ids[0]})",
-            ItemType.tag,
-            tag_names[0],
-        )
-
-    # Bulk path: resolve all tags up front, then loop the cartesian product.
+    # Resolve all tags up front, then loop the cartesian product.
     tag_map = _resolve_tag_ids(client, tag_names)
 
     results: List[Tuple[str, str, bool, str]] = []
@@ -327,13 +297,12 @@ async def untag_note(
     Both args accept a single string or a list. When either is a list, the cartesian
     product is applied (remove every tag from every note) in one call.
 
-    Output shape:
-    - Scalar note_id + scalar tag_name: single-op success line (unchanged).
-    - Any list input: aggregated UNTAG_NOTE report with TOTAL_OPS / SUCCEEDED / FAILED.
+    Output: aggregated UNTAG_NOTE report with TOTAL_OPS / SUCCEEDED / FAILED, one row
+    per (note, tag) pair (so the scalar case is a one-row report).
 
     Tags must exist (by name). Missing tags are reported up front and nothing is
-    removed. Per-op failures are captured in the aggregated report; other ops still
-    run.
+    removed. Per-op failures (including allowlist denials) are captured in the
+    report; other ops still run.
 
     Examples:
         - untag_note("abc...", "Work") - Remove one tag from one note
@@ -341,7 +310,6 @@ async def untag_note(
         - untag_note("abc...", ["Work", "Urgent"]) - Remove two tags from one note
         - untag_note(["abc...", "def..."], ["Work", "Urgent"]) - 2x2 = 4 ops
     """
-    scalar_inputs = isinstance(note_id, str) and isinstance(tag_name, str)
     note_ids = [note_id] if isinstance(note_id, str) else list(note_id)
     tag_names = [tag_name] if isinstance(tag_name, str) else list(tag_name)
     if not note_ids:
@@ -351,35 +319,7 @@ async def untag_note(
 
     client = get_joplin_client()
 
-    if scalar_inputs:
-        # Preserve existing single-op output format for backwards compatibility.
-        try:
-            note = client.get_note(note_ids[0], fields=COMMON_NOTE_FIELDS)
-            note_title = getattr(note, "title", "Unknown Note")
-        except Exception:
-            raise ValueError(
-                f"Note with ID '{note_ids[0]}' not found. "
-                "Use find_notes to find available notes."
-            )
-
-        # Allowlist validation: ensure note is in an accessible notebook
-        if _module_config.has_notebook_allowlist:
-            parent_id = getattr(note, "parent_id", "")
-            validate_notebook_access(
-                parent_id, allowlist_entries=_module_config.notebook_allowlist
-            )
-
-        tag_id = get_tag_id_by_name(tag_names[0])
-        client.delete(f"/tags/{tag_id}/notes/{note_ids[0]}")
-        return format_relation_success(
-            "removed tag from note",
-            ItemType.note,
-            f"{note_title} (ID: {note_ids[0]})",
-            ItemType.tag,
-            tag_names[0],
-        )
-
-    # Bulk path: resolve all tags up front, then loop the cartesian product.
+    # Resolve all tags up front, then loop the cartesian product.
     tag_map = _resolve_tag_ids(client, tag_names)
 
     results: List[Tuple[str, str, bool, str]] = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -364,6 +364,44 @@ def mock_notebook_hierarchy():
     return {"notebooks": notebooks, "nb_map": nb_map, "ids": ids}
 
 
+@pytest.fixture(autouse=True)
+def _no_notebook_allowlist():
+    """Disable notebook allowlist for all tests by default.
+
+    This prevents any real allowlist configuration from leaking into tests.
+    Tests that need an allowlist should patch _module_config themselves.
+    """
+    from unittest.mock import patch
+
+    targets = [
+        "joplin_mcp.tools.notes._module_config",
+        "joplin_mcp.tools.notebooks._module_config",
+        "joplin_mcp.tools.tags._module_config",
+    ]
+    patches = []
+    for target in targets:
+        try:
+            p = patch(target)
+            mock_cfg = p.start()
+            mock_cfg.has_notebook_allowlist = False
+            mock_cfg.notebook_allowlist = None
+            # Preserve other config attributes that tools may need
+            mock_cfg.should_show_content.return_value = True
+            mock_cfg.should_show_full_content.return_value = True
+            mock_cfg.get_max_preview_length.return_value = 300
+            mock_cfg.is_smart_toc_enabled.return_value = False
+            mock_cfg.get_smart_toc_threshold.return_value = 2000
+            mock_cfg.tools = {}
+            patches.append(p)
+        except ModuleNotFoundError:
+            continue
+        except Exception as exc:
+            pytest.fail(f"Failed to patch {target} in _no_notebook_allowlist: {exc}")
+    yield
+    for p in patches:
+        p.stop()
+
+
 @pytest.fixture
 def anyio_backend():
     """Configure anyio backend for async testing."""

--- a/tests/test_fastmcp_server.py
+++ b/tests/test_fastmcp_server.py
@@ -417,6 +417,109 @@ def test_find_notebook_suggestions_exact_match_first():
     assert suggestions[0] == "personal"  # Exact match first
 
 
+def test_get_notebook_id_by_name_flat_hides_denied_notebooks():
+    """Flat-name not-found error must not leak titles of allowlist-denied notebooks."""
+    from unittest.mock import patch
+    from joplin_mcp.notebook_utils import get_notebook_id_by_name
+
+    # Two top-level notebooks; only "Work" is allowlisted.
+    full_map = {
+        "work_id": {"title": "Work", "parent_id": None},
+        "secret_id": {"title": "Secrets", "parent_id": None},
+    }
+
+    mock_cfg = type("C", (), {})()
+    mock_cfg.has_notebook_allowlist = True
+    mock_cfg.notebook_allowlist = ["Work"]
+
+    with patch(
+        "joplin_mcp.notebook_utils.get_notebook_map_cached",
+        return_value=full_map,
+    ), patch("joplin_mcp.fastmcp_server._module_config", mock_cfg):
+        with pytest.raises(ValueError) as exc_info:
+            get_notebook_id_by_name("NonExistent")
+        msg = str(exc_info.value)
+        assert "Secrets" not in msg
+        assert "Available notebooks" not in msg
+
+
+def test_get_notebook_id_by_name_flat_resolves_allowlisted():
+    """Flat name in the allowlisted set must still resolve."""
+    from unittest.mock import patch
+    from joplin_mcp.notebook_utils import get_notebook_id_by_name
+
+    full_map = {
+        "work_id": {"title": "Work", "parent_id": None},
+        "secret_id": {"title": "Secrets", "parent_id": None},
+    }
+
+    mock_cfg = type("C", (), {})()
+    mock_cfg.has_notebook_allowlist = True
+    mock_cfg.notebook_allowlist = ["Work"]
+
+    with patch(
+        "joplin_mcp.notebook_utils.get_notebook_map_cached",
+        return_value=full_map,
+    ), patch("joplin_mcp.fastmcp_server._module_config", mock_cfg):
+        assert get_notebook_id_by_name("Work") == "work_id"
+
+
+def test_get_notebook_id_by_name_flat_multi_match_only_lists_accessible():
+    """Multi-match disambiguation must not surface denied notebook paths."""
+    from unittest.mock import patch
+    from joplin_mcp.notebook_utils import get_notebook_id_by_name
+
+    # Two notebooks both named "Inbox": one under allowed Work, one under denied Personal.
+    full_map = {
+        "work_id": {"title": "Work", "parent_id": None},
+        "work_inbox_id": {"title": "Inbox", "parent_id": "work_id"},
+        "personal_id": {"title": "Personal", "parent_id": None},
+        "personal_inbox_id": {"title": "Inbox", "parent_id": "personal_id"},
+    }
+
+    mock_cfg = type("C", (), {})()
+    mock_cfg.has_notebook_allowlist = True
+    mock_cfg.notebook_allowlist = ["Work", "Work/**"]
+
+    with patch(
+        "joplin_mcp.notebook_utils.get_notebook_map_cached",
+        return_value=full_map,
+    ), patch("joplin_mcp.fastmcp_server._module_config", mock_cfg):
+        # Only Work/Inbox is accessible — single match, should resolve cleanly.
+        assert get_notebook_id_by_name("Inbox") == "work_inbox_id"
+
+
+def test_get_notebook_id_by_name_flat_multi_match_disambiguation_filtered():
+    """When multiple accessible notebooks share a name, paths come from the filtered map."""
+    from unittest.mock import patch
+    from joplin_mcp.notebook_utils import get_notebook_id_by_name
+
+    full_map = {
+        "work_id": {"title": "Work", "parent_id": None},
+        "work_inbox_id": {"title": "Inbox", "parent_id": "work_id"},
+        "ai_id": {"title": "AI", "parent_id": None},
+        "ai_inbox_id": {"title": "Inbox", "parent_id": "ai_id"},
+        "personal_id": {"title": "Personal", "parent_id": None},
+        "personal_inbox_id": {"title": "Inbox", "parent_id": "personal_id"},
+    }
+
+    mock_cfg = type("C", (), {})()
+    mock_cfg.has_notebook_allowlist = True
+    mock_cfg.notebook_allowlist = ["Work", "Work/**", "AI", "AI/**"]
+
+    with patch(
+        "joplin_mcp.notebook_utils.get_notebook_map_cached",
+        return_value=full_map,
+    ), patch("joplin_mcp.fastmcp_server._module_config", mock_cfg):
+        with pytest.raises(ValueError) as exc_info:
+            get_notebook_id_by_name("Inbox")
+        msg = str(exc_info.value)
+        assert "Work/Inbox" in msg
+        assert "AI/Inbox" in msg
+        assert "Personal/Inbox" not in msg
+        assert "Personal" not in msg
+
+
 def test_resolve_notebook_by_path_suggests_on_not_found():
     """Test _resolve_notebook_by_path provides suggestions when path component not found."""
     from unittest.mock import patch

--- a/tests/test_integration_allowlist.py
+++ b/tests/test_integration_allowlist.py
@@ -1,0 +1,834 @@
+"""Integration tests for end-to-end notebook allowlist workflow.
+
+These tests exercise the full stack from config through notebook_utils
+through tools, with only the Joplin API mocked. They verify:
+- D2: Hierarchical access (parent allowlist grants child access)
+- D3: Startup validation (server starts with valid/invalid allowlist)
+- D4: All enforcement points (full tool chain exercised)
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from joplin_mcp.config import JoplinMCPConfig
+from joplin_mcp.notebook_utils import (
+    filter_accessible_notebooks,
+    invalidate_notebook_map_cache,
+    is_notebook_accessible,
+    validate_notebook_access,
+    validate_allowlist_at_startup,
+)
+
+
+def _get_tool_fn(tool):
+    """Get the underlying function from a tool (handles both wrapped and unwrapped)."""
+    if hasattr(tool, "fn"):
+        return tool.fn
+    return tool
+
+
+def _make_mock_client(notebooks):
+    """Create a mock Joplin client that returns the given notebook list."""
+    client = MagicMock()
+    client.get_all_notebooks.return_value = notebooks
+    client.ping.return_value = "JoplinClipperServer"
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Test 1: End-to-end allowlist workflow
+# Config -> startup validation -> tool call -> access check
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEndAllowlistWorkflow:
+    """Integration test: config with allowlist, startup, tool calls, access checks."""
+
+    def setup_method(self):
+        invalidate_notebook_map_cache()
+
+    def test_config_to_access_check_flow(self, mock_notebook_hierarchy):
+        """Full workflow: create config, validate startup, check access.
+
+        Exercises: JoplinMCPConfig -> validate_allowlist_at_startup ->
+        is_notebook_accessible for allowed and denied notebooks.
+        """
+        ids = mock_notebook_hierarchy["ids"]
+        notebooks = mock_notebook_hierarchy["notebooks"]
+        client = _make_mock_client(notebooks)
+
+        # Step 1: Create config with allowlist
+        config = JoplinMCPConfig(
+            token="test_token",
+            notebook_allowlist=["Projects", "AI"],
+        )
+        assert config.has_notebook_allowlist is True
+        assert config.notebook_allowlist == ["Projects", "AI"]
+
+        # Step 2: Validate at startup (should not raise)
+        validate_allowlist_at_startup(config, client)
+
+        # Step 3: Check access for allowlisted notebooks
+        client_fn = lambda: client  # noqa: E731
+        invalidate_notebook_map_cache()
+
+        assert is_notebook_accessible(
+            ids["Projects"], allowlist_entries=config.notebook_allowlist,
+            client_fn=client_fn,
+        ) is True
+
+        assert is_notebook_accessible(
+            ids["AI"], allowlist_entries=config.notebook_allowlist,
+            client_fn=client_fn,
+        ) is True
+
+        # Step 4: Check access denied for non-allowlisted notebooks
+        assert is_notebook_accessible(
+            ids["Personal"], allowlist_entries=config.notebook_allowlist,
+            client_fn=client_fn,
+        ) is False
+
+        assert is_notebook_accessible(
+            ids["Diary"], allowlist_entries=config.notebook_allowlist,
+            client_fn=client_fn,
+        ) is False
+
+    @pytest.mark.asyncio
+    async def test_tool_call_with_allowlist_allowed(self, mock_notebook_hierarchy):
+        """Tool call succeeds for note in allowlisted notebook."""
+        ids = mock_notebook_hierarchy["ids"]
+        notebooks = mock_notebook_hierarchy["notebooks"]
+        client = _make_mock_client(notebooks)
+        client_fn = lambda: client  # noqa: E731
+
+        # Mock note in an allowlisted notebook (Projects/Work)
+        mock_note = MagicMock()
+        mock_note.parent_id = ids["Work"]
+        mock_note.title = "Work Note"
+        mock_note.body = "Work content"
+        mock_note.id = "a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0"
+        mock_note.created_time = 1609459200000
+        mock_note.updated_time = 1609545600000
+        mock_note.is_todo = 0
+        mock_note.todo_completed = 0
+        client.get_note.return_value = mock_note
+
+        allowlist = ["Projects"]
+
+        with (
+            patch("joplin_mcp.tools.notes._module_config") as mock_cfg,
+            patch("joplin_mcp.tools.notes.get_joplin_client", return_value=client),
+            patch(
+                "joplin_mcp.tools.notes.validate_notebook_access",
+                side_effect=lambda nb_id, allowlist_entries=None, **kw: (
+                    # Use real validation with our mock client
+                    validate_notebook_access(
+                        nb_id,
+                        allowlist_entries=allowlist_entries,
+                        client_fn=client_fn,
+                    )
+                ),
+            ),
+        ):
+            mock_cfg.has_notebook_allowlist = True
+            mock_cfg.notebook_allowlist = allowlist
+            mock_cfg.should_show_content.return_value = True
+            mock_cfg.should_show_full_content.return_value = True
+            mock_cfg.get_max_preview_length.return_value = 300
+            mock_cfg.is_smart_toc_enabled.return_value = False
+            mock_cfg.get_smart_toc_threshold.return_value = 2000
+            mock_cfg.tools = {}
+
+            from joplin_mcp.tools.notes import get_note
+
+            fn = _get_tool_fn(get_note)
+            result = await fn(note_id="a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0")
+
+            assert "Work Note" in result
+
+    @pytest.mark.asyncio
+    async def test_tool_call_with_allowlist_denied(self, mock_notebook_hierarchy):
+        """Tool call raises ValueError for note in non-allowlisted notebook."""
+        ids = mock_notebook_hierarchy["ids"]
+        notebooks = mock_notebook_hierarchy["notebooks"]
+        client = _make_mock_client(notebooks)
+        client_fn = lambda: client  # noqa: E731
+
+        # Mock note in a non-allowlisted notebook (Personal/Diary)
+        mock_note = MagicMock()
+        mock_note.parent_id = ids["Diary"]
+        client.get_note.return_value = mock_note
+
+        allowlist = ["Projects"]
+
+        with (
+            patch("joplin_mcp.tools.notes._module_config") as mock_cfg,
+            patch("joplin_mcp.tools.notes.get_joplin_client", return_value=client),
+            patch(
+                "joplin_mcp.tools.notes.validate_notebook_access",
+                side_effect=lambda nb_id, allowlist_entries=None, **kw: (
+                    validate_notebook_access(
+                        nb_id,
+                        allowlist_entries=allowlist_entries,
+                        client_fn=client_fn,
+                    )
+                ),
+            ),
+        ):
+            mock_cfg.has_notebook_allowlist = True
+            mock_cfg.notebook_allowlist = allowlist
+            mock_cfg.should_show_content.return_value = True
+            mock_cfg.should_show_full_content.return_value = True
+            mock_cfg.get_max_preview_length.return_value = 300
+            mock_cfg.is_smart_toc_enabled.return_value = False
+            mock_cfg.get_smart_toc_threshold.return_value = 2000
+            mock_cfg.tools = {}
+
+            from joplin_mcp.tools.notes import get_note
+
+            fn = _get_tool_fn(get_note)
+            with pytest.raises(ValueError, match="Notebook not accessible"):
+                await fn(note_id="b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1")
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Hierarchical access integration (D2)
+# Allowlist parent, verify child notebook note operations work
+# ---------------------------------------------------------------------------
+
+
+class TestHierarchicalAccessIntegration:
+    """Integration test: allowlist parent grants access to child notebook notes."""
+
+    def setup_method(self):
+        invalidate_notebook_map_cache()
+
+    def test_parent_allowlist_grants_child_access(self, mock_notebook_hierarchy):
+        """Allowlisting 'Projects' grants access to notes in Projects/Work and Projects/Fun."""
+        ids = mock_notebook_hierarchy["ids"]
+        notebooks = mock_notebook_hierarchy["notebooks"]
+        client = _make_mock_client(notebooks)
+        client_fn = lambda: client  # noqa: E731
+
+        allowlist = ["Projects"]
+
+        # Direct child: Projects/Work
+        assert is_notebook_accessible(
+            ids["Work"], allowlist_entries=allowlist, client_fn=client_fn,
+        ) is True
+
+        invalidate_notebook_map_cache()
+        # Direct child: Projects/Fun
+        assert is_notebook_accessible(
+            ids["Fun"], allowlist_entries=allowlist, client_fn=client_fn,
+        ) is True
+
+        invalidate_notebook_map_cache()
+        # Non-child: Personal
+        assert is_notebook_accessible(
+            ids["Personal"], allowlist_entries=allowlist, client_fn=client_fn,
+        ) is False
+
+    def test_deep_hierarchy_access(self):
+        """Allowlisting top-level grants access through multiple levels."""
+        invalidate_notebook_map_cache()
+
+        # Build a 3-level hierarchy: Root > Middle > Deep
+        notebooks = [
+            SimpleNamespace(id="root_id_000000000000000000000", title="Root", parent_id=""),
+            SimpleNamespace(id="mid_id_0000000000000000000000", title="Middle", parent_id="root_id_000000000000000000000"),
+            SimpleNamespace(id="deep_id_000000000000000000000", title="Deep", parent_id="mid_id_0000000000000000000000"),
+        ]
+        client = _make_mock_client(notebooks)
+        client_fn = lambda: client  # noqa: E731
+
+        # Allowlist only "Root" -- should grant access to Root/Middle/Deep
+        assert is_notebook_accessible(
+            "deep_id_000000000000000000000",
+            allowlist_entries=["Root"],
+            client_fn=client_fn,
+        ) is True
+
+    @pytest.mark.asyncio
+    async def test_create_note_in_child_of_allowlisted_parent(
+        self, mock_notebook_hierarchy
+    ):
+        """create_note succeeds when target notebook is child of allowlisted parent."""
+        ids = mock_notebook_hierarchy["ids"]
+        notebooks = mock_notebook_hierarchy["notebooks"]
+        client = _make_mock_client(notebooks)
+        client.add_note.return_value = "new_note_in_work_id"
+        client_fn = lambda: client  # noqa: E731
+
+        allowlist = ["Projects"]
+
+        with (
+            patch("joplin_mcp.tools.notes._module_config") as mock_cfg,
+            patch("joplin_mcp.tools.notes.get_joplin_client", return_value=client),
+            patch(
+                "joplin_mcp.tools.notes.get_notebook_id_by_name",
+                return_value=ids["Work"],
+            ),
+            patch(
+                "joplin_mcp.tools.notes.validate_notebook_access",
+                side_effect=lambda nb_id, allowlist_entries=None, **kw: (
+                    validate_notebook_access(
+                        nb_id,
+                        allowlist_entries=allowlist_entries,
+                        client_fn=client_fn,
+                    )
+                ),
+            ),
+        ):
+            mock_cfg.has_notebook_allowlist = True
+            mock_cfg.notebook_allowlist = allowlist
+            mock_cfg.should_show_content.return_value = True
+            mock_cfg.should_show_full_content.return_value = True
+            mock_cfg.get_max_preview_length.return_value = 300
+            mock_cfg.is_smart_toc_enabled.return_value = False
+            mock_cfg.get_smart_toc_threshold.return_value = 2000
+            mock_cfg.tools = {}
+
+            from joplin_mcp.tools.notes import create_note
+
+            fn = _get_tool_fn(create_note)
+            result = await fn(title="Work Task", notebook_name="Work", body="task body")
+            assert "SUCCESS" in result
+
+    @pytest.mark.asyncio
+    async def test_create_note_in_non_child_denied(self, mock_notebook_hierarchy):
+        """create_note fails when target notebook is NOT a child of allowlisted parent."""
+        ids = mock_notebook_hierarchy["ids"]
+        notebooks = mock_notebook_hierarchy["notebooks"]
+        client = _make_mock_client(notebooks)
+        client_fn = lambda: client  # noqa: E731
+
+        allowlist = ["Projects"]
+
+        with (
+            patch("joplin_mcp.tools.notes._module_config") as mock_cfg,
+            patch("joplin_mcp.tools.notes.get_joplin_client", return_value=client),
+            patch(
+                "joplin_mcp.tools.notes.get_notebook_id_by_name",
+                return_value=ids["Diary"],
+            ),
+            patch(
+                "joplin_mcp.tools.notes.validate_notebook_access",
+                side_effect=lambda nb_id, allowlist_entries=None, **kw: (
+                    validate_notebook_access(
+                        nb_id,
+                        allowlist_entries=allowlist_entries,
+                        client_fn=client_fn,
+                    )
+                ),
+            ),
+        ):
+            mock_cfg.has_notebook_allowlist = True
+            mock_cfg.notebook_allowlist = allowlist
+            mock_cfg.should_show_content.return_value = True
+            mock_cfg.should_show_full_content.return_value = True
+            mock_cfg.get_max_preview_length.return_value = 300
+            mock_cfg.is_smart_toc_enabled.return_value = False
+            mock_cfg.get_smart_toc_threshold.return_value = 2000
+            mock_cfg.tools = {}
+
+            from joplin_mcp.tools.notes import create_note
+
+            fn = _get_tool_fn(create_note)
+            with pytest.raises(ValueError, match="Notebook not accessible"):
+                await fn(title="Diary Entry", notebook_name="Diary", body="private")
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Backward compatibility (no allowlist configured)
+# All operations succeed when allowlist is not set
+# ---------------------------------------------------------------------------
+
+
+class TestBackwardCompatibilityIntegration:
+    """Integration test: no allowlist configured, all tools work normally."""
+
+    def setup_method(self):
+        invalidate_notebook_map_cache()
+
+    @pytest.mark.asyncio
+    async def test_get_note_works_without_allowlist(self):
+        """get_note succeeds for any notebook when no allowlist is configured."""
+        mock_note = MagicMock()
+        mock_note.parent_id = "any_notebook_id_0000000000000000"
+        mock_note.title = "Any Note"
+        mock_note.body = "content"
+        mock_note.id = "12345678901234567890123456789012"
+        mock_note.created_time = 1609459200000
+        mock_note.updated_time = 1609545600000
+        mock_note.is_todo = 0
+        mock_note.todo_completed = 0
+
+        mock_client = MagicMock()
+        mock_client.get_note.return_value = mock_note
+
+        with (
+            patch("joplin_mcp.tools.notes._module_config") as mock_cfg,
+            patch("joplin_mcp.tools.notes.get_joplin_client", return_value=mock_client),
+        ):
+            mock_cfg.has_notebook_allowlist = False
+            mock_cfg.notebook_allowlist = None
+            mock_cfg.should_show_content.return_value = True
+            mock_cfg.should_show_full_content.return_value = True
+            mock_cfg.get_max_preview_length.return_value = 300
+            mock_cfg.is_smart_toc_enabled.return_value = False
+            mock_cfg.get_smart_toc_threshold.return_value = 2000
+            mock_cfg.tools = {}
+
+            from joplin_mcp.tools.notes import get_note
+
+            fn = _get_tool_fn(get_note)
+            result = await fn(note_id="12345678901234567890123456789012")
+            assert "Any Note" in result
+
+    @pytest.mark.asyncio
+    async def test_create_note_works_without_allowlist(self):
+        """create_note succeeds for any notebook when no allowlist is configured."""
+        mock_client = MagicMock()
+        mock_client.add_note.return_value = "new_note_id"
+
+        with (
+            patch("joplin_mcp.tools.notes._module_config") as mock_cfg,
+            patch("joplin_mcp.tools.notes.get_joplin_client", return_value=mock_client),
+            patch(
+                "joplin_mcp.tools.notes.get_notebook_id_by_name",
+                return_value="any_nb_id",
+            ),
+        ):
+            mock_cfg.has_notebook_allowlist = False
+            mock_cfg.notebook_allowlist = None
+            mock_cfg.should_show_content.return_value = True
+            mock_cfg.should_show_full_content.return_value = True
+            mock_cfg.get_max_preview_length.return_value = 300
+            mock_cfg.is_smart_toc_enabled.return_value = False
+            mock_cfg.get_smart_toc_threshold.return_value = 2000
+            mock_cfg.tools = {}
+
+            from joplin_mcp.tools.notes import create_note
+
+            fn = _get_tool_fn(create_note)
+            result = await fn(title="Free Note", notebook_name="Anywhere", body="hi")
+            assert "SUCCESS" in result
+
+    @pytest.mark.asyncio
+    async def test_list_notebooks_returns_all_without_allowlist(self):
+        """list_notebooks returns all notebooks when no allowlist is configured."""
+        mock_notebooks = [
+            MagicMock(id="nb1", title="Work"),
+            MagicMock(id="nb2", title="Personal"),
+            MagicMock(id="nb3", title="Secret"),
+        ]
+        mock_client = MagicMock()
+        mock_client.get_all_notebooks.return_value = mock_notebooks
+
+        with (
+            patch("joplin_mcp.tools.notebooks._module_config") as mock_cfg,
+            patch(
+                "joplin_mcp.tools.notebooks.get_joplin_client",
+                return_value=mock_client,
+            ),
+            patch("joplin_mcp.tools.notebooks.format_item_list") as mock_format,
+        ):
+            mock_cfg.has_notebook_allowlist = False
+            mock_cfg.notebook_allowlist = None
+
+            mock_format.return_value = "ALL_NOTEBOOKS_LISTED"
+
+            from joplin_mcp.tools.notebooks import list_notebooks
+
+            fn = _get_tool_fn(list_notebooks)
+            result = await fn()
+
+            assert result == "ALL_NOTEBOOKS_LISTED"
+            # format_item_list should have received all 3 notebooks
+            from joplin_mcp.fastmcp_server import ItemType
+
+            mock_format.assert_called_once_with(mock_notebooks, ItemType.notebook)
+
+    @pytest.mark.asyncio
+    async def test_delete_note_works_without_allowlist(self):
+        """delete_note succeeds for any notebook when no allowlist is configured."""
+        mock_client = MagicMock()
+
+        with (
+            patch("joplin_mcp.tools.notes._module_config") as mock_cfg,
+            patch("joplin_mcp.tools.notes.get_joplin_client", return_value=mock_client),
+        ):
+            mock_cfg.has_notebook_allowlist = False
+            mock_cfg.notebook_allowlist = None
+            mock_cfg.should_show_content.return_value = True
+            mock_cfg.should_show_full_content.return_value = True
+            mock_cfg.get_max_preview_length.return_value = 300
+            mock_cfg.is_smart_toc_enabled.return_value = False
+            mock_cfg.get_smart_toc_threshold.return_value = 2000
+            mock_cfg.tools = {}
+
+            from joplin_mcp.tools.notes import delete_note
+
+            fn = _get_tool_fn(delete_note)
+            result = await fn(note_id="12345678901234567890123456789012")
+            assert "SUCCESS" in result
+
+    def test_config_without_allowlist_property(self):
+        """JoplinMCPConfig with no notebook_allowlist has has_notebook_allowlist=False."""
+        config = JoplinMCPConfig(token="test_token")
+        assert config.has_notebook_allowlist is False
+        assert config.notebook_allowlist == JoplinMCPConfig.ALLOW_ALL
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Mixed pattern types
+# Allowlist with exact path + glob pattern + ID, verify all work together
+# ---------------------------------------------------------------------------
+
+
+class TestMixedPatternTypesIntegration:
+    """Integration test: allowlist with IDs, paths, and globs all work together."""
+
+    def setup_method(self):
+        invalidate_notebook_map_cache()
+
+    def test_exact_path_and_glob_combined(self, mock_notebook_hierarchy):
+        """Allowlist with exact path 'AI' and glob 'Projects/*' both work."""
+        ids = mock_notebook_hierarchy["ids"]
+        notebooks = mock_notebook_hierarchy["notebooks"]
+        client = _make_mock_client(notebooks)
+        client_fn = lambda: client  # noqa: E731
+
+        allowlist = ["AI", "Projects/*"]
+
+        # Exact path match: AI
+        assert is_notebook_accessible(
+            ids["AI"], allowlist_entries=allowlist, client_fn=client_fn,
+        ) is True
+
+        invalidate_notebook_map_cache()
+        # Glob match: Projects/Work
+        assert is_notebook_accessible(
+            ids["Work"], allowlist_entries=allowlist, client_fn=client_fn,
+        ) is True
+
+        invalidate_notebook_map_cache()
+        # Glob match: Projects/Fun
+        assert is_notebook_accessible(
+            ids["Fun"], allowlist_entries=allowlist, client_fn=client_fn,
+        ) is True
+
+        invalidate_notebook_map_cache()
+        # Non-matching: Personal
+        assert is_notebook_accessible(
+            ids["Personal"], allowlist_entries=allowlist, client_fn=client_fn,
+        ) is False
+
+        invalidate_notebook_map_cache()
+        # Non-matching: Personal/Diary
+        assert is_notebook_accessible(
+            ids["Diary"], allowlist_entries=allowlist, client_fn=client_fn,
+        ) is False
+
+    def test_negation_with_mixed_patterns(self, mock_notebook_hierarchy):
+        """Negation pattern excludes specific child from glob match."""
+        ids = mock_notebook_hierarchy["ids"]
+        notebooks = mock_notebook_hierarchy["notebooks"]
+        client = _make_mock_client(notebooks)
+        client_fn = lambda: client  # noqa: E731
+
+        allowlist = ["Projects/*", "!Projects/Fun"]
+
+        # Projects/Work should be accessible
+        assert is_notebook_accessible(
+            ids["Work"], allowlist_entries=allowlist, client_fn=client_fn,
+        ) is True
+
+        invalidate_notebook_map_cache()
+        # Projects/Fun should be denied by negation
+        assert is_notebook_accessible(
+            ids["Fun"], allowlist_entries=allowlist, client_fn=client_fn,
+        ) is False
+
+    def test_id_based_allowlist_entry(self):
+        """Allowlist with raw 32-char hex notebook ID works alongside path patterns."""
+        # Use real 32-char hex IDs so _HEX_ID_RE matches for ID-based allowlisting
+        personal_id = "aabbccddee11223344556677aabbccdd"
+        ai_id = "11223344556677889900aabbccddeeff"
+        projects_id = "ffeeddccbbaa99887766554433221100"
+
+        notebooks = [
+            SimpleNamespace(id=projects_id, title="Projects", parent_id=""),
+            SimpleNamespace(id=personal_id, title="Personal", parent_id=""),
+            SimpleNamespace(id=ai_id, title="AI", parent_id=""),
+        ]
+        client = _make_mock_client(notebooks)
+        client_fn = lambda: client  # noqa: E731
+
+        # Mix a raw hex ID with a path pattern
+        allowlist = [personal_id, "AI"]
+
+        # Personal accessible by hex ID
+        assert is_notebook_accessible(
+            personal_id, allowlist_entries=allowlist, client_fn=client_fn,
+        ) is True
+
+        invalidate_notebook_map_cache()
+        # AI accessible by path
+        assert is_notebook_accessible(
+            ai_id, allowlist_entries=allowlist, client_fn=client_fn,
+        ) is True
+
+        invalidate_notebook_map_cache()
+        # Projects not accessible (not in allowlist)
+        assert is_notebook_accessible(
+            projects_id, allowlist_entries=allowlist, client_fn=client_fn,
+        ) is False
+
+    @pytest.mark.asyncio
+    async def test_find_notes_filters_with_mixed_allowlist(
+        self, mock_notebook_hierarchy
+    ):
+        """find_notes returns only notes in notebooks matching mixed allowlist."""
+        ids = mock_notebook_hierarchy["ids"]
+        notebooks = mock_notebook_hierarchy["notebooks"]
+        client = _make_mock_client(notebooks)
+        client_fn = lambda: client  # noqa: E731
+
+        note_in_work = MagicMock()
+        note_in_work.parent_id = ids["Work"]
+        note_in_work.id = "work_note_id_00000000000000000000"
+        note_in_work.title = "Work Task"
+        note_in_work.updated_time = 1609545600000
+        note_in_work.is_todo = 0
+        note_in_work.todo_completed = 0
+
+        note_in_ai = MagicMock()
+        note_in_ai.parent_id = ids["AI"]
+        note_in_ai.id = "ai_note_id_0000000000000000000000"
+        note_in_ai.title = "AI Research"
+        note_in_ai.updated_time = 1609545600000
+        note_in_ai.is_todo = 0
+        note_in_ai.todo_completed = 0
+
+        note_in_diary = MagicMock()
+        note_in_diary.parent_id = ids["Diary"]
+        note_in_diary.id = "diary_note_id_000000000000000000"
+        note_in_diary.title = "Private Diary Entry"
+        note_in_diary.updated_time = 1609459200000
+        note_in_diary.is_todo = 0
+        note_in_diary.todo_completed = 0
+
+        client.get_all_notes.return_value = [note_in_work, note_in_ai, note_in_diary]
+
+        allowlist = ["AI", "Projects/*"]
+
+        with (
+            patch("joplin_mcp.tools.notes._module_config") as mock_cfg,
+            patch("joplin_mcp.tools.notes.get_joplin_client", return_value=client),
+            patch(
+                "joplin_mcp.tools.notes.is_notebook_accessible",
+                side_effect=lambda parent_id, allowlist_entries=None, **kw: (
+                    is_notebook_accessible(
+                        parent_id,
+                        allowlist_entries=allowlist_entries,
+                        client_fn=client_fn,
+                    )
+                ),
+            ),
+        ):
+            mock_cfg.has_notebook_allowlist = True
+            mock_cfg.notebook_allowlist = allowlist
+            mock_cfg.should_show_content.return_value = True
+            mock_cfg.should_show_full_content.return_value = True
+            mock_cfg.get_max_preview_length.return_value = 300
+            mock_cfg.is_smart_toc_enabled.return_value = False
+            mock_cfg.get_smart_toc_threshold.return_value = 2000
+            mock_cfg.tools = {}
+
+            from joplin_mcp.tools.notes import find_notes
+
+            fn = _get_tool_fn(find_notes)
+            result = await fn(query="*", limit=20)
+
+            assert "Work Task" in result
+            assert "AI Research" in result
+            assert "Private Diary Entry" not in result
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Startup validation integration (D3)
+# Server starts with valid/invalid allowlist configurations
+# ---------------------------------------------------------------------------
+
+
+class TestStartupValidationIntegration:
+    """Integration test: startup validation with various allowlist configs."""
+
+    def setup_method(self):
+        invalidate_notebook_map_cache()
+
+    def test_startup_with_valid_allowlist(self, mock_notebook_hierarchy):
+        """Server starts successfully with valid allowlist entries."""
+        notebooks = mock_notebook_hierarchy["notebooks"]
+        client = _make_mock_client(notebooks)
+
+        config = JoplinMCPConfig(
+            token="test_token",
+            notebook_allowlist=["Projects", "AI"],
+        )
+
+        # Should not raise
+        validate_allowlist_at_startup(config, client)
+
+    def test_startup_with_invalid_entries(self, mock_notebook_hierarchy):
+        """Server starts successfully even with unresolvable allowlist entries (D3)."""
+        notebooks = mock_notebook_hierarchy["notebooks"]
+        client = _make_mock_client(notebooks)
+
+        config = JoplinMCPConfig(
+            token="test_token",
+            notebook_allowlist=["NonExistent/Path", "GhostNotebook"],
+        )
+
+        # Per D3: server always starts, never raises
+        validate_allowlist_at_startup(config, client)
+
+    def test_startup_with_no_allowlist(self):
+        """Server starts successfully with no allowlist configured."""
+        client = MagicMock()
+        config = JoplinMCPConfig(token="test_token")
+
+        # Should not raise
+        validate_allowlist_at_startup(config, client)
+
+    def test_startup_with_empty_allowlist(self, mock_notebook_hierarchy):
+        """Server starts successfully with empty allowlist (D3: never crashes)."""
+        notebooks = mock_notebook_hierarchy["notebooks"]
+        client = _make_mock_client(notebooks)
+
+        config = JoplinMCPConfig(
+            token="test_token",
+            notebook_allowlist=[],
+        )
+
+        # Should not raise, even though empty allowlist means no access
+        validate_allowlist_at_startup(config, client)
+
+    def test_startup_with_mixed_valid_invalid(self, mock_notebook_hierarchy):
+        """Server starts with mix of valid and invalid entries, logging warnings."""
+        notebooks = mock_notebook_hierarchy["notebooks"]
+        client = _make_mock_client(notebooks)
+
+        config = JoplinMCPConfig(
+            token="test_token",
+            notebook_allowlist=["Projects", "NonExistent", "AI"],
+        )
+
+        # Should not raise; valid entries still work
+        validate_allowlist_at_startup(config, client)
+
+        # Verify accessible notebooks still work after startup
+        client_fn = lambda: client  # noqa: E731
+        invalidate_notebook_map_cache()
+        projects_id = [
+            nb.id for nb in notebooks if nb.title == "Projects"
+        ][0]
+
+        assert is_notebook_accessible(
+            projects_id,
+            allowlist_entries=config.notebook_allowlist,
+            client_fn=client_fn,
+        ) is True
+
+    def test_startup_warns_on_zero_accessible_notebooks(self):
+        """When allowlist resolves to zero notebooks, warn but do not auto-create."""
+        from unittest.mock import patch as _patch
+
+        invalidate_notebook_map_cache()
+
+        client = _make_mock_client([])
+
+        config = JoplinMCPConfig(
+            token="test_token",
+            notebook_allowlist=["SomePattern"],
+        )
+
+        with _patch("joplin_mcp.notebook_utils.logger") as mock_logger:
+            validate_allowlist_at_startup(config, client)
+        mock_logger.warning.assert_any_call(
+            "Allowlist is configured but resolves to zero accessible "
+            "notebooks -- check your allowlist configuration"
+        )
+        client.add_notebook.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test 6: Filter accessible notebooks integration
+# filter_accessible_notebooks with real notebook_utils logic
+# ---------------------------------------------------------------------------
+
+
+class TestFilterAccessibleNotebooksIntegration:
+    """Integration test: filter_accessible_notebooks with real hierarchy."""
+
+    def setup_method(self):
+        invalidate_notebook_map_cache()
+
+    def test_filter_returns_only_accessible(self, mock_notebook_hierarchy):
+        """filter_accessible_notebooks returns only allowlisted notebooks."""
+        notebooks = mock_notebook_hierarchy["notebooks"]
+        client = _make_mock_client(notebooks)
+        client_fn = lambda: client  # noqa: E731
+
+        allowlist = ["Projects", "AI"]
+
+        result = filter_accessible_notebooks(
+            notebooks, allowlist_entries=allowlist, client_fn=client_fn,
+        )
+
+        result_titles = {nb.title for nb in result}
+        # Projects itself, its children (Work, Fun via hierarchical), and AI
+        assert "Projects" in result_titles
+        assert "Work" in result_titles
+        assert "Fun" in result_titles
+        assert "AI" in result_titles
+        # Personal and Diary should be excluded
+        assert "Personal" not in result_titles
+        assert "Diary" not in result_titles
+
+    def test_filter_with_allow_all_returns_all(self):
+        """filter_accessible_notebooks returns all notebooks when allowlist is ALLOW_ALL (no restrictions)."""
+        notebooks = [SimpleNamespace(id="nb1", title="Work")]
+        client = _make_mock_client(notebooks)
+        client_fn = lambda: client  # noqa: E731
+        result = filter_accessible_notebooks(
+            notebooks,
+            allowlist_entries=list(JoplinMCPConfig.ALLOW_ALL),
+            client_fn=client_fn,
+        )
+        assert len(result) == 1
+        assert result[0].id == "nb1"
+
+    def test_filter_with_glob_pattern(self, mock_notebook_hierarchy):
+        """filter_accessible_notebooks works with glob patterns."""
+        notebooks = mock_notebook_hierarchy["notebooks"]
+        client = _make_mock_client(notebooks)
+        client_fn = lambda: client  # noqa: E731
+
+        allowlist = ["Projects/*"]
+
+        result = filter_accessible_notebooks(
+            notebooks, allowlist_entries=allowlist, client_fn=client_fn,
+        )
+
+        result_titles = {nb.title for nb in result}
+        assert "Work" in result_titles
+        assert "Fun" in result_titles
+        # Projects itself is not matched by "Projects/*" (only children)
+        # Personal and Diary should be excluded
+        assert "Personal" not in result_titles
+        assert "Diary" not in result_titles

--- a/tests/test_tools_notebooks_allowlist.py
+++ b/tests/test_tools_notebooks_allowlist.py
@@ -1,0 +1,466 @@
+"""Tests for notebook tool allowlist enforcement."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _get_tool_fn(tool):
+    """Get the underlying function from a tool (handles both wrapped and unwrapped)."""
+    if hasattr(tool, "fn"):
+        return tool.fn
+    return tool
+
+
+# === Fixtures ===
+
+
+@pytest.fixture
+def mock_allowlist_config():
+    """Enable allowlist in _module_config for notebook tools."""
+    with patch("joplin_mcp.tools.notebooks._module_config") as mock_cfg:
+        mock_cfg.has_notebook_allowlist = True
+        mock_cfg.notebook_allowlist = ["AI", "Projects/*"]
+        yield mock_cfg
+
+
+@pytest.fixture
+def mock_no_allowlist_config():
+    """Explicitly disable allowlist in _module_config for backward compat tests."""
+    with patch("joplin_mcp.tools.notebooks._module_config") as mock_cfg:
+        mock_cfg.has_notebook_allowlist = False
+        mock_cfg.notebook_allowlist = None
+        yield mock_cfg
+
+
+# === Tests for list_notebooks with allowlist ===
+
+
+class TestListNotebooksAllowlist:
+    """Tests for list_notebooks allowlist filtering."""
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notebooks.format_item_list")
+    @patch("joplin_mcp.tools.notebooks.get_joplin_client")
+    async def test_list_notebooks_no_allowlist(
+        self, mock_get_client, mock_format, mock_no_allowlist_config
+    ):
+        """All notebooks returned when no allowlist configured."""
+        from joplin_mcp.tools.notebooks import list_notebooks
+
+        mock_notebooks = [
+            MagicMock(id="nb1", title="Work"),
+            MagicMock(id="nb2", title="Personal"),
+        ]
+        mock_client = MagicMock()
+        mock_client.get_all_notebooks.return_value = mock_notebooks
+        mock_get_client.return_value = mock_client
+        mock_format.return_value = "ALL_NOTEBOOKS"
+
+        fn = _get_tool_fn(list_notebooks)
+        result = await fn()
+
+        # filter_accessible_notebooks should NOT be called
+        from joplin_mcp.fastmcp_server import ItemType
+
+        mock_format.assert_called_once_with(mock_notebooks, ItemType.notebook)
+        assert result == "ALL_NOTEBOOKS"
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notebooks.filter_accessible_notebooks")
+    @patch("joplin_mcp.tools.notebooks.format_item_list")
+    @patch("joplin_mcp.tools.notebooks.get_joplin_client")
+    async def test_list_notebooks_with_allowlist(
+        self,
+        mock_get_client,
+        mock_format,
+        mock_filter,
+        mock_allowlist_config,
+    ):
+        """Only matching notebooks returned when allowlist configured."""
+        from joplin_mcp.tools.notebooks import list_notebooks
+
+        all_notebooks = [
+            MagicMock(id="nb1", title="AI"),
+            MagicMock(id="nb2", title="Personal"),
+            MagicMock(id="nb3", title="Projects"),
+        ]
+        filtered = [all_notebooks[0], all_notebooks[2]]
+
+        mock_client = MagicMock()
+        mock_client.get_all_notebooks.return_value = all_notebooks
+        mock_get_client.return_value = mock_client
+        mock_filter.return_value = filtered
+        mock_format.return_value = "FILTERED_NOTEBOOKS"
+
+        fn = _get_tool_fn(list_notebooks)
+        result = await fn()
+
+        mock_filter.assert_called_once_with(
+            all_notebooks,
+            allowlist_entries=mock_allowlist_config.notebook_allowlist,
+        )
+        from joplin_mcp.fastmcp_server import ItemType
+
+        mock_format.assert_called_once_with(filtered, ItemType.notebook)
+        assert result == "FILTERED_NOTEBOOKS"
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notebooks.format_item_list")
+    @patch("joplin_mcp.tools.notebooks.get_joplin_client")
+    async def test_list_notebooks_empty_allowlist(
+        self, mock_get_client, mock_format
+    ):
+        """All notebooks returned when allowlist is empty list (same as none)."""
+        # Empty allowlist = has_notebook_allowlist is False in config
+        with patch("joplin_mcp.tools.notebooks._module_config") as mock_cfg:
+            mock_cfg.has_notebook_allowlist = False
+            mock_cfg.notebook_allowlist = []
+
+            from joplin_mcp.tools.notebooks import list_notebooks
+
+            mock_notebooks = [MagicMock(id="nb1", title="Work")]
+            mock_client = MagicMock()
+            mock_client.get_all_notebooks.return_value = mock_notebooks
+            mock_get_client.return_value = mock_client
+            mock_format.return_value = "ALL"
+
+            fn = _get_tool_fn(list_notebooks)
+            result = await fn()
+
+            from joplin_mcp.fastmcp_server import ItemType
+
+            mock_format.assert_called_once_with(mock_notebooks, ItemType.notebook)
+            assert result == "ALL"
+
+
+# === Tests for create_notebook with allowlist ===
+
+
+class TestCreateNotebookAllowlist:
+    """Tests for create_notebook allowlist validation."""
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notebooks.validate_notebook_access")
+    @patch("joplin_mcp.tools.notebooks.invalidate_notebook_map_cache")
+    @patch("joplin_mcp.tools.notebooks.get_joplin_client")
+    async def test_create_notebook_allowlisted_parent(
+        self,
+        mock_get_client,
+        mock_invalidate,
+        mock_validate,
+        mock_allowlist_config,
+    ):
+        """Should succeed when parent notebook is allowlisted."""
+        from joplin_mcp.tools.notebooks import create_notebook
+
+        mock_client = MagicMock()
+        mock_client.add_notebook.return_value = "new_nb_id"
+        mock_get_client.return_value = mock_client
+
+        fn = _get_tool_fn(create_notebook)
+        result = await fn(title="Sub Notebook", parent_id="allowlisted_parent_id")
+
+        mock_validate.assert_called_once_with(
+            "allowlisted_parent_id",
+            allowlist_entries=mock_allowlist_config.notebook_allowlist,
+        )
+        mock_client.add_notebook.assert_called_once()
+        assert "SUCCESS" in result
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notebooks.validate_notebook_access")
+    @patch("joplin_mcp.tools.notebooks.invalidate_notebook_map_cache")
+    @patch("joplin_mcp.tools.notebooks.get_joplin_client")
+    async def test_create_notebook_non_allowlisted_parent(
+        self,
+        mock_get_client,
+        mock_invalidate,
+        mock_validate,
+        mock_allowlist_config,
+    ):
+        """Should raise error when parent notebook is not allowlisted."""
+        from joplin_mcp.tools.notebooks import create_notebook
+
+        mock_validate.side_effect = ValueError("Notebook not accessible")
+
+        fn = _get_tool_fn(create_notebook)
+        with pytest.raises(ValueError, match="Notebook not accessible"):
+            await fn(title="Bad Notebook", parent_id="blocked_parent_id")
+
+        # Verify error message is generic (D7) -- no notebook details leaked
+        mock_validate.assert_called_once()
+        mock_client = mock_get_client.return_value
+        mock_client.add_notebook.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notebooks.invalidate_notebook_map_cache")
+    @patch("joplin_mcp.tools.notebooks.get_joplin_client")
+    async def test_create_notebook_no_parent_no_allowlist(
+        self,
+        mock_get_client,
+        mock_invalidate,
+        mock_no_allowlist_config,
+    ):
+        """Top-level notebook creation succeeds when no allowlist configured."""
+        from joplin_mcp.tools.notebooks import create_notebook
+
+        mock_client = MagicMock()
+        mock_client.add_notebook.return_value = "top_nb_id"
+        mock_get_client.return_value = mock_client
+
+        fn = _get_tool_fn(create_notebook)
+        result = await fn(title="Top Level")
+
+        mock_client.add_notebook.assert_called_once_with(title="Top Level")
+        assert "SUCCESS" in result
+
+    @pytest.mark.asyncio
+    async def test_create_notebook_no_parent_with_allowlist_blocked(
+        self,
+        mock_allowlist_config,
+    ):
+        """Top-level notebook creation blocked when allowlist is active (no bypass)."""
+        from joplin_mcp.tools.notebooks import create_notebook
+
+        fn = _get_tool_fn(create_notebook)
+        with pytest.raises(ValueError, match="Notebook not accessible"):
+            await fn(title="Rogue Top Level")
+
+
+# === Tests for update_notebook with allowlist ===
+
+
+class TestUpdateNotebookAllowlist:
+    """Tests for update_notebook allowlist validation."""
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notebooks.validate_notebook_access")
+    @patch("joplin_mcp.tools.notebooks.invalidate_notebook_map_cache")
+    @patch("joplin_mcp.tools.notebooks.get_joplin_client")
+    async def test_update_notebook_allowlisted(
+        self,
+        mock_get_client,
+        mock_invalidate,
+        mock_validate,
+        mock_allowlist_config,
+    ):
+        """Should succeed when notebook is allowlisted."""
+        from joplin_mcp.tools.notebooks import update_notebook
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        fn = _get_tool_fn(update_notebook)
+        result = await fn(
+            notebook_id="12345678901234567890123456789012",
+            title="Renamed",
+        )
+
+        mock_validate.assert_called_once_with(
+            "12345678901234567890123456789012",
+            allowlist_entries=mock_allowlist_config.notebook_allowlist,
+        )
+        mock_client.modify_notebook.assert_called_once()
+        assert "SUCCESS" in result
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notebooks.validate_notebook_access")
+    @patch("joplin_mcp.tools.notebooks.invalidate_notebook_map_cache")
+    @patch("joplin_mcp.tools.notebooks.get_joplin_client")
+    async def test_update_notebook_non_allowlisted(
+        self,
+        mock_get_client,
+        mock_invalidate,
+        mock_validate,
+        mock_allowlist_config,
+    ):
+        """Should raise error when notebook is not allowlisted."""
+        from joplin_mcp.tools.notebooks import update_notebook
+
+        mock_validate.side_effect = ValueError("Notebook not accessible")
+
+        fn = _get_tool_fn(update_notebook)
+        with pytest.raises(ValueError, match="Notebook not accessible"):
+            await fn(
+                notebook_id="blocked_nb_id_0000000000000000",
+                title="Should Fail",
+            )
+
+        mock_client = mock_get_client.return_value
+        mock_client.modify_notebook.assert_not_called()
+
+
+# === Tests for delete_notebook with allowlist ===
+
+
+class TestDeleteNotebookAllowlist:
+    """Tests for delete_notebook allowlist validation."""
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notebooks.validate_notebook_access")
+    @patch("joplin_mcp.tools.notebooks.invalidate_notebook_map_cache")
+    @patch("joplin_mcp.tools.notebooks.get_joplin_client")
+    async def test_delete_notebook_allowlisted(
+        self,
+        mock_get_client,
+        mock_invalidate,
+        mock_validate,
+        mock_allowlist_config,
+    ):
+        """Should succeed when notebook is allowlisted."""
+        from joplin_mcp.tools.notebooks import delete_notebook
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        fn = _get_tool_fn(delete_notebook)
+        result = await fn(notebook_id="12345678901234567890123456789012")
+
+        mock_validate.assert_called_once_with(
+            "12345678901234567890123456789012",
+            allowlist_entries=mock_allowlist_config.notebook_allowlist,
+        )
+        mock_client.delete_notebook.assert_called_once()
+        assert "SUCCESS" in result
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notebooks.validate_notebook_access")
+    @patch("joplin_mcp.tools.notebooks.invalidate_notebook_map_cache")
+    @patch("joplin_mcp.tools.notebooks.get_joplin_client")
+    async def test_delete_notebook_non_allowlisted(
+        self,
+        mock_get_client,
+        mock_invalidate,
+        mock_validate,
+        mock_allowlist_config,
+    ):
+        """Should raise error when notebook is not allowlisted."""
+        from joplin_mcp.tools.notebooks import delete_notebook
+
+        mock_validate.side_effect = ValueError("Notebook not accessible")
+
+        fn = _get_tool_fn(delete_notebook)
+        with pytest.raises(ValueError, match="Notebook not accessible"):
+            await fn(notebook_id="blocked_nb_id_0000000000000000")
+
+        mock_client = mock_get_client.return_value
+        mock_client.delete_notebook.assert_not_called()
+
+
+# === Backward compatibility tests ===
+
+
+class TestNotebookAllowlistBackwardCompat:
+    """Verify all notebook tools work normally when no allowlist is configured."""
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notebooks.format_item_list")
+    @patch("joplin_mcp.tools.notebooks.get_joplin_client")
+    async def test_list_notebooks_works_without_allowlist(
+        self, mock_get_client, mock_format, mock_no_allowlist_config
+    ):
+        """list_notebooks returns all notebooks when no allowlist."""
+        from joplin_mcp.tools.notebooks import list_notebooks
+
+        mock_notebooks = [MagicMock(id="nb1"), MagicMock(id="nb2")]
+        mock_client = MagicMock()
+        mock_client.get_all_notebooks.return_value = mock_notebooks
+        mock_get_client.return_value = mock_client
+        mock_format.return_value = "OK"
+
+        fn = _get_tool_fn(list_notebooks)
+        result = await fn()
+        assert result == "OK"
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notebooks.invalidate_notebook_map_cache")
+    @patch("joplin_mcp.tools.notebooks.get_joplin_client")
+    async def test_create_notebook_works_without_allowlist(
+        self, mock_get_client, mock_invalidate, mock_no_allowlist_config
+    ):
+        """create_notebook succeeds without allowlist."""
+        from joplin_mcp.tools.notebooks import create_notebook
+
+        mock_client = MagicMock()
+        mock_client.add_notebook.return_value = "id"
+        mock_get_client.return_value = mock_client
+
+        fn = _get_tool_fn(create_notebook)
+        result = await fn(title="Test")
+        assert "SUCCESS" in result
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notebooks.invalidate_notebook_map_cache")
+    @patch("joplin_mcp.tools.notebooks.get_joplin_client")
+    async def test_update_notebook_works_without_allowlist(
+        self, mock_get_client, mock_invalidate, mock_no_allowlist_config
+    ):
+        """update_notebook succeeds without allowlist."""
+        from joplin_mcp.tools.notebooks import update_notebook
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        fn = _get_tool_fn(update_notebook)
+        result = await fn(
+            notebook_id="12345678901234567890123456789012", title="New"
+        )
+        assert "SUCCESS" in result
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notebooks.invalidate_notebook_map_cache")
+    @patch("joplin_mcp.tools.notebooks.get_joplin_client")
+    async def test_delete_notebook_works_without_allowlist(
+        self, mock_get_client, mock_invalidate, mock_no_allowlist_config
+    ):
+        """delete_notebook succeeds without allowlist."""
+        from joplin_mcp.tools.notebooks import delete_notebook
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        fn = _get_tool_fn(delete_notebook)
+        result = await fn(notebook_id="12345678901234567890123456789012")
+        assert "SUCCESS" in result
+
+
+# === Error message tests (D7) ===
+
+
+class TestNotebookAllowlistErrorMessages:
+    """Verify error messages are generic and do not leak notebook details."""
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notebooks.validate_notebook_access")
+    @patch("joplin_mcp.tools.notebooks.get_joplin_client")
+    async def test_error_does_not_contain_notebook_id(
+        self, mock_get_client, mock_validate, mock_allowlist_config
+    ):
+        """Error message should not contain the notebook ID."""
+        from joplin_mcp.tools.notebooks import update_notebook
+
+        blocked_id = "secret_notebook_id_00000000000000"
+        mock_validate.side_effect = ValueError("Notebook not accessible")
+
+        fn = _get_tool_fn(update_notebook)
+        with pytest.raises(ValueError) as exc_info:
+            await fn(notebook_id=blocked_id, title="X")
+
+        error_msg = str(exc_info.value)
+        assert blocked_id not in error_msg
+        assert "secret" not in error_msg.lower()
+        assert "Notebook not accessible" in error_msg
+
+    @pytest.mark.asyncio
+    async def test_create_top_level_error_is_generic(self, mock_allowlist_config):
+        """Top-level creation error should be generic."""
+        from joplin_mcp.tools.notebooks import create_notebook
+
+        fn = _get_tool_fn(create_notebook)
+        with pytest.raises(ValueError) as exc_info:
+            await fn(title="My Secret Notebook")
+
+        error_msg = str(exc_info.value)
+        assert "My Secret Notebook" not in error_msg
+        assert "Notebook not accessible" in error_msg

--- a/tests/test_tools_notes_allowlist.py
+++ b/tests/test_tools_notes_allowlist.py
@@ -1,0 +1,966 @@
+"""Tests for note tool allowlist enforcement."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _get_tool_fn(tool):
+    """Get the underlying function from a tool (handles both wrapped and unwrapped)."""
+    if hasattr(tool, "fn"):
+        return tool.fn
+    return tool
+
+
+# === Fixtures ===
+
+
+@pytest.fixture
+def mock_allowlist_config():
+    """Enable allowlist in _module_config for note tools."""
+    with patch("joplin_mcp.tools.notes._module_config") as mock_cfg:
+        mock_cfg.has_notebook_allowlist = True
+        mock_cfg.notebook_allowlist = ["AI", "Projects/*"]
+        # Preserve other config attributes that note tools may need
+        mock_cfg.should_show_content.return_value = True
+        mock_cfg.should_show_full_content.return_value = True
+        mock_cfg.get_max_preview_length.return_value = 300
+        mock_cfg.is_smart_toc_enabled.return_value = False
+        mock_cfg.get_smart_toc_threshold.return_value = 2000
+        mock_cfg.tools = {}
+        yield mock_cfg
+
+
+@pytest.fixture
+def mock_no_allowlist_config():
+    """Explicitly disable allowlist in _module_config for backward compat tests."""
+    with patch("joplin_mcp.tools.notes._module_config") as mock_cfg:
+        mock_cfg.has_notebook_allowlist = False
+        mock_cfg.notebook_allowlist = None
+        mock_cfg.should_show_content.return_value = True
+        mock_cfg.should_show_full_content.return_value = True
+        mock_cfg.get_max_preview_length.return_value = 300
+        mock_cfg.is_smart_toc_enabled.return_value = False
+        mock_cfg.get_smart_toc_threshold.return_value = 2000
+        mock_cfg.tools = {}
+        yield mock_cfg
+
+
+# === Tests for create_note with allowlist ===
+
+
+class TestCreateNoteAllowlist:
+    """Tests for create_note allowlist validation."""
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes.validate_notebook_access")
+    @patch("joplin_mcp.tools.notes.get_notebook_id_by_name")
+    @patch("joplin_mcp.tools.notes.get_joplin_client")
+    async def test_create_note_allowlisted_notebook(
+        self,
+        mock_get_client,
+        mock_get_nb_id,
+        mock_validate,
+        mock_allowlist_config,
+    ):
+        """Should succeed when target notebook is allowlisted."""
+        from joplin_mcp.tools.notes import create_note
+
+        mock_get_nb_id.return_value = "allowlisted_nb_id"
+        mock_client = MagicMock()
+        mock_client.add_note.return_value = "new_note_id"
+        mock_get_client.return_value = mock_client
+
+        fn = _get_tool_fn(create_note)
+        result = await fn(title="Test Note", notebook_name="AI", body="content")
+
+        mock_validate.assert_called_once_with(
+            "allowlisted_nb_id",
+            allowlist_entries=mock_allowlist_config.notebook_allowlist,
+        )
+        mock_client.add_note.assert_called_once()
+        assert "SUCCESS" in result
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes.validate_notebook_access")
+    @patch("joplin_mcp.tools.notes.get_notebook_id_by_name")
+    @patch("joplin_mcp.tools.notes.get_joplin_client")
+    async def test_create_note_non_allowlisted_notebook(
+        self,
+        mock_get_client,
+        mock_get_nb_id,
+        mock_validate,
+        mock_allowlist_config,
+    ):
+        """Should raise error when target notebook is not allowlisted."""
+        from joplin_mcp.tools.notes import create_note
+
+        mock_get_nb_id.return_value = "blocked_nb_id"
+        mock_validate.side_effect = ValueError("Notebook not accessible")
+
+        fn = _get_tool_fn(create_note)
+        with pytest.raises(ValueError, match="Notebook not accessible"):
+            await fn(title="Bad Note", notebook_name="Secret", body="content")
+
+        mock_client = mock_get_client.return_value
+        mock_client.add_note.assert_not_called()
+
+
+# === Tests for get_note with allowlist ===
+
+
+class TestGetNoteAllowlist:
+    """Tests for get_note allowlist validation."""
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes.validate_notebook_access")
+    @patch("joplin_mcp.tools.notes.get_joplin_client")
+    async def test_get_note_allowlisted(
+        self,
+        mock_get_client,
+        mock_validate,
+        mock_allowlist_config,
+    ):
+        """Should succeed when note is in an allowlisted notebook."""
+        from joplin_mcp.tools.notes import get_note
+
+        mock_note = MagicMock()
+        mock_note.parent_id = "allowlisted_nb_id"
+        mock_note.title = "Test Note"
+        mock_note.body = "content"
+        mock_note.id = "12345678901234567890123456789012"
+        mock_note.created_time = 1609459200000
+        mock_note.updated_time = 1609545600000
+        mock_note.is_todo = 0
+        mock_note.todo_completed = 0
+
+        mock_client = MagicMock()
+        mock_client.get_note.return_value = mock_note
+        mock_get_client.return_value = mock_client
+
+        fn = _get_tool_fn(get_note)
+        # Should not raise
+        result = await fn(note_id="12345678901234567890123456789012")
+
+        mock_validate.assert_called_once_with(
+            "allowlisted_nb_id",
+            allowlist_entries=mock_allowlist_config.notebook_allowlist,
+        )
+        assert result is not None
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes.validate_notebook_access")
+    @patch("joplin_mcp.tools.notes.get_joplin_client")
+    async def test_get_note_non_allowlisted(
+        self,
+        mock_get_client,
+        mock_validate,
+        mock_allowlist_config,
+    ):
+        """Should raise error when note is in a non-allowlisted notebook."""
+        from joplin_mcp.tools.notes import get_note
+
+        mock_note = MagicMock()
+        mock_note.parent_id = "blocked_nb_id"
+
+        mock_client = MagicMock()
+        mock_client.get_note.return_value = mock_note
+        mock_get_client.return_value = mock_client
+
+        mock_validate.side_effect = ValueError("Notebook not accessible")
+
+        fn = _get_tool_fn(get_note)
+        with pytest.raises(ValueError, match="Notebook not accessible"):
+            await fn(note_id="12345678901234567890123456789012")
+
+
+# === Tests for update_note with allowlist ===
+
+
+class TestUpdateNoteAllowlist:
+    """Tests for update_note allowlist validation."""
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes.validate_notebook_access")
+    @patch("joplin_mcp.tools.notes.get_joplin_client")
+    async def test_update_note_allowlisted(
+        self,
+        mock_get_client,
+        mock_validate,
+        mock_allowlist_config,
+    ):
+        """Should succeed when note is in an allowlisted notebook."""
+        from joplin_mcp.tools.notes import update_note
+
+        mock_note = MagicMock()
+        mock_note.parent_id = "allowlisted_nb_id"
+
+        mock_client = MagicMock()
+        mock_client.get_note.return_value = mock_note
+        mock_get_client.return_value = mock_client
+
+        fn = _get_tool_fn(update_note)
+        result = await fn(
+            note_id="12345678901234567890123456789012",
+            title="Updated Title",
+        )
+
+        mock_validate.assert_called_once_with(
+            "allowlisted_nb_id",
+            allowlist_entries=mock_allowlist_config.notebook_allowlist,
+        )
+        mock_client.modify_note.assert_called_once()
+        assert "SUCCESS" in result
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes.validate_notebook_access")
+    @patch("joplin_mcp.tools.notes.get_joplin_client")
+    async def test_update_note_non_allowlisted(
+        self,
+        mock_get_client,
+        mock_validate,
+        mock_allowlist_config,
+    ):
+        """Should raise error when note is in a non-allowlisted notebook."""
+        from joplin_mcp.tools.notes import update_note
+
+        mock_note = MagicMock()
+        mock_note.parent_id = "blocked_nb_id"
+
+        mock_client = MagicMock()
+        mock_client.get_note.return_value = mock_note
+        mock_get_client.return_value = mock_client
+
+        mock_validate.side_effect = ValueError("Notebook not accessible")
+
+        fn = _get_tool_fn(update_note)
+        with pytest.raises(ValueError, match="Notebook not accessible"):
+            await fn(
+                note_id="12345678901234567890123456789012",
+                title="Should Fail",
+            )
+
+        mock_client.modify_note.assert_not_called()
+
+
+# === Tests for edit_note with allowlist ===
+
+
+class TestEditNoteAllowlist:
+    """Tests for edit_note allowlist validation."""
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes.validate_notebook_access")
+    @patch("joplin_mcp.tools.notes.get_joplin_client")
+    async def test_edit_note_allowlisted(
+        self,
+        mock_get_client,
+        mock_validate,
+        mock_allowlist_config,
+    ):
+        """Should succeed when note is in an allowlisted notebook."""
+        from joplin_mcp.tools.notes import edit_note
+
+        mock_note = MagicMock()
+        mock_note.parent_id = "allowlisted_nb_id"
+        mock_note.body = "old text here"
+        mock_note.title = "Test"
+        mock_note.id = "12345678901234567890123456789012"
+
+        mock_client = MagicMock()
+        mock_client.get_note.return_value = mock_note
+        mock_get_client.return_value = mock_client
+
+        fn = _get_tool_fn(edit_note)
+        result = await fn(
+            note_id="12345678901234567890123456789012",
+            old_string="old text",
+            new_string="new text",
+        )
+
+        mock_validate.assert_called_once_with(
+            "allowlisted_nb_id",
+            allowlist_entries=mock_allowlist_config.notebook_allowlist,
+        )
+        assert "EDIT_NOTE" in result
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes.validate_notebook_access")
+    @patch("joplin_mcp.tools.notes.get_joplin_client")
+    async def test_edit_note_non_allowlisted(
+        self,
+        mock_get_client,
+        mock_validate,
+        mock_allowlist_config,
+    ):
+        """Should raise error when note is in a non-allowlisted notebook."""
+        from joplin_mcp.tools.notes import edit_note
+
+        mock_note = MagicMock()
+        mock_note.parent_id = "blocked_nb_id"
+        mock_note.body = "content"
+
+        mock_client = MagicMock()
+        mock_client.get_note.return_value = mock_note
+        mock_get_client.return_value = mock_client
+
+        mock_validate.side_effect = ValueError("Notebook not accessible")
+
+        fn = _get_tool_fn(edit_note)
+        with pytest.raises(ValueError, match="Notebook not accessible"):
+            await fn(
+                note_id="12345678901234567890123456789012",
+                old_string="content",
+                new_string="modified",
+            )
+
+        mock_client.modify_note.assert_not_called()
+
+
+# === Tests for delete_note with allowlist ===
+
+
+class TestDeleteNoteAllowlist:
+    """Tests for delete_note allowlist validation."""
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes.validate_notebook_access")
+    @patch("joplin_mcp.tools.notes.get_joplin_client")
+    async def test_delete_note_allowlisted(
+        self,
+        mock_get_client,
+        mock_validate,
+        mock_allowlist_config,
+    ):
+        """Should succeed when note is in an allowlisted notebook."""
+        from joplin_mcp.tools.notes import delete_note
+
+        mock_note = MagicMock()
+        mock_note.parent_id = "allowlisted_nb_id"
+
+        mock_client = MagicMock()
+        mock_client.get_note.return_value = mock_note
+        mock_get_client.return_value = mock_client
+
+        fn = _get_tool_fn(delete_note)
+        result = await fn(note_id="12345678901234567890123456789012")
+
+        mock_validate.assert_called_once_with(
+            "allowlisted_nb_id",
+            allowlist_entries=mock_allowlist_config.notebook_allowlist,
+        )
+        mock_client.delete_note.assert_called_once()
+        assert "SUCCESS" in result
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes.validate_notebook_access")
+    @patch("joplin_mcp.tools.notes.get_joplin_client")
+    async def test_delete_note_non_allowlisted(
+        self,
+        mock_get_client,
+        mock_validate,
+        mock_allowlist_config,
+    ):
+        """Should raise error when note is in a non-allowlisted notebook."""
+        from joplin_mcp.tools.notes import delete_note
+
+        mock_note = MagicMock()
+        mock_note.parent_id = "blocked_nb_id"
+
+        mock_client = MagicMock()
+        mock_client.get_note.return_value = mock_note
+        mock_get_client.return_value = mock_client
+
+        mock_validate.side_effect = ValueError("Notebook not accessible")
+
+        fn = _get_tool_fn(delete_note)
+        with pytest.raises(ValueError, match="Notebook not accessible"):
+            await fn(note_id="12345678901234567890123456789012")
+
+        mock_client.delete_note.assert_not_called()
+
+
+# === Tests for find_notes with allowlist ===
+
+
+class TestFindNotesAllowlist:
+    """Tests for find_notes allowlist filtering."""
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes.is_notebook_accessible")
+    @patch("joplin_mcp.tools.notes.get_joplin_client")
+    async def test_find_notes_filters_results(
+        self,
+        mock_get_client,
+        mock_is_accessible,
+        mock_allowlist_config,
+    ):
+        """Only notes in allowlisted notebooks should be returned."""
+        from joplin_mcp.tools.notes import find_notes
+
+        note_ok = MagicMock()
+        note_ok.parent_id = "allowlisted_nb_id"
+        note_ok.id = "note_ok_id_000000000000000000000"
+        note_ok.title = "Good Note"
+        note_ok.updated_time = 1609545600000
+        note_ok.is_todo = 0
+        note_ok.todo_completed = 0
+
+        note_blocked = MagicMock()
+        note_blocked.parent_id = "blocked_nb_id"
+        note_blocked.id = "note_blocked_id_0000000000000000"
+        note_blocked.title = "Secret Note"
+        note_blocked.updated_time = 1609459200000
+        note_blocked.is_todo = 0
+        note_blocked.todo_completed = 0
+
+        mock_client = MagicMock()
+        mock_client.get_all_notes.return_value = [note_ok, note_blocked]
+        mock_get_client.return_value = mock_client
+
+        def accessible_side_effect(parent_id, allowlist_entries=None):
+            return parent_id == "allowlisted_nb_id"
+
+        mock_is_accessible.side_effect = accessible_side_effect
+
+        fn = _get_tool_fn(find_notes)
+        result = await fn(query="*", limit=20)
+
+        # is_notebook_accessible should have been called for filtering
+        assert mock_is_accessible.call_count >= 1
+        # Result should contain the good note but not the blocked one
+        assert "Good Note" in result
+        assert "Secret Note" not in result
+
+
+# === Tests for find_notes_with_tag with allowlist ===
+
+
+class TestFindNotesWithTagAllowlist:
+    """Tests for find_notes_with_tag allowlist filtering."""
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes.is_notebook_accessible")
+    @patch("joplin_mcp.tools.notes.get_joplin_client")
+    async def test_find_notes_with_tag_filters_results(
+        self,
+        mock_get_client,
+        mock_is_accessible,
+        mock_allowlist_config,
+    ):
+        """Only notes in allowlisted notebooks returned for tag search."""
+        from joplin_mcp.tools.notes import find_notes_with_tag
+
+        note_ok = MagicMock()
+        note_ok.parent_id = "allowlisted_nb_id"
+        note_ok.id = "note_ok_id_000000000000000000000"
+        note_ok.title = "Tagged Good Note"
+        note_ok.updated_time = 1609545600000
+        note_ok.is_todo = 0
+        note_ok.todo_completed = 0
+
+        note_blocked = MagicMock()
+        note_blocked.parent_id = "blocked_nb_id"
+        note_blocked.id = "note_blocked_id_0000000000000000"
+        note_blocked.title = "Tagged Secret Note"
+        note_blocked.updated_time = 1609459200000
+        note_blocked.is_todo = 0
+        note_blocked.todo_completed = 0
+
+        mock_client = MagicMock()
+        mock_client.search_all.return_value = [note_ok, note_blocked]
+        mock_get_client.return_value = mock_client
+
+        def accessible_side_effect(parent_id, allowlist_entries=None):
+            return parent_id == "allowlisted_nb_id"
+
+        mock_is_accessible.side_effect = accessible_side_effect
+
+        fn = _get_tool_fn(find_notes_with_tag)
+        result = await fn(tag_name="work")
+
+        assert mock_is_accessible.call_count >= 1
+        assert "Tagged Good Note" in result
+        assert "Tagged Secret Note" not in result
+
+
+# === Tests for find_notes_in_notebook with allowlist ===
+
+
+class TestFindNotesInNotebookAllowlist:
+    """Tests for find_notes_in_notebook allowlist validation."""
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes.validate_notebook_access")
+    @patch("joplin_mcp.tools.notes.get_notebook_id_by_name")
+    @patch("joplin_mcp.tools.notes.get_joplin_client")
+    async def test_find_notes_in_notebook_allowlisted(
+        self,
+        mock_get_client,
+        mock_get_nb_id,
+        mock_validate,
+        mock_allowlist_config,
+    ):
+        """Should succeed when target notebook is allowlisted."""
+        from joplin_mcp.tools.notes import find_notes_in_notebook
+
+        mock_get_nb_id.return_value = "allowlisted_nb_id"
+
+        note = MagicMock()
+        note.parent_id = "allowlisted_nb_id"
+        note.id = "note_id_00000000000000000000000"
+        note.title = "Note in Allowlisted"
+        note.updated_time = 1609545600000
+        note.is_todo = 0
+        note.todo_completed = 0
+
+        mock_client = MagicMock()
+        mock_client.get_all_notes.return_value = [note]
+        mock_get_client.return_value = mock_client
+
+        fn = _get_tool_fn(find_notes_in_notebook)
+        result = await fn(notebook_name="AI")
+
+        mock_validate.assert_called_once_with(
+            "allowlisted_nb_id",
+            allowlist_entries=mock_allowlist_config.notebook_allowlist,
+        )
+        assert "Note in Allowlisted" in result
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes.validate_notebook_access")
+    @patch("joplin_mcp.tools.notes.get_notebook_id_by_name")
+    @patch("joplin_mcp.tools.notes.get_joplin_client")
+    async def test_find_notes_in_notebook_non_allowlisted(
+        self,
+        mock_get_client,
+        mock_get_nb_id,
+        mock_validate,
+        mock_allowlist_config,
+    ):
+        """Should raise error when target notebook is not allowlisted."""
+        from joplin_mcp.tools.notes import find_notes_in_notebook
+
+        mock_get_nb_id.return_value = "blocked_nb_id"
+        mock_validate.side_effect = ValueError("Notebook not accessible")
+
+        fn = _get_tool_fn(find_notes_in_notebook)
+        with pytest.raises(ValueError, match="Notebook not accessible"):
+            await fn(notebook_name="Secret")
+
+
+# === Tests for get_all_notes with allowlist ===
+
+
+class TestGetAllNotesAllowlist:
+    """Tests for get_all_notes allowlist filtering."""
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes.is_notebook_accessible")
+    @patch("joplin_mcp.tools.notes.get_joplin_client")
+    async def test_get_all_notes_filters_results(
+        self,
+        mock_get_client,
+        mock_is_accessible,
+        mock_allowlist_config,
+    ):
+        """Only notes in allowlisted notebooks should be returned."""
+        from joplin_mcp.tools.notes import get_all_notes
+
+        note_ok = MagicMock()
+        note_ok.parent_id = "allowlisted_nb_id"
+        note_ok.id = "note_ok_id_000000000000000000000"
+        note_ok.title = "Allowed Note"
+        note_ok.updated_time = 1609545600000
+        note_ok.is_todo = 0
+        note_ok.todo_completed = 0
+
+        note_blocked = MagicMock()
+        note_blocked.parent_id = "blocked_nb_id"
+        note_blocked.id = "note_blocked_id_0000000000000000"
+        note_blocked.title = "Hidden Note"
+        note_blocked.updated_time = 1609459200000
+        note_blocked.is_todo = 0
+        note_blocked.todo_completed = 0
+
+        mock_client = MagicMock()
+        mock_client.get_all_notes.return_value = [note_ok, note_blocked]
+        mock_get_client.return_value = mock_client
+
+        def accessible_side_effect(parent_id, allowlist_entries=None):
+            return parent_id == "allowlisted_nb_id"
+
+        mock_is_accessible.side_effect = accessible_side_effect
+
+        fn = _get_tool_fn(get_all_notes)
+        result = await fn()
+
+        assert mock_is_accessible.call_count >= 1
+        assert "Allowed Note" in result
+        assert "Hidden Note" not in result
+
+
+# === Backward compatibility tests ===
+
+
+class TestNoteAllowlistBackwardCompat:
+    """Verify all note tools work normally when no allowlist is configured."""
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes.get_notebook_id_by_name")
+    @patch("joplin_mcp.tools.notes.get_joplin_client")
+    async def test_create_note_works_without_allowlist(
+        self,
+        mock_get_client,
+        mock_get_nb_id,
+        mock_no_allowlist_config,
+    ):
+        """create_note succeeds without allowlist."""
+        from joplin_mcp.tools.notes import create_note
+
+        mock_get_nb_id.return_value = "nb_id"
+        mock_client = MagicMock()
+        mock_client.add_note.return_value = "note_id"
+        mock_get_client.return_value = mock_client
+
+        fn = _get_tool_fn(create_note)
+        result = await fn(title="Test", notebook_name="Work", body="content")
+        assert "SUCCESS" in result
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes.get_joplin_client")
+    async def test_get_note_works_without_allowlist(
+        self,
+        mock_get_client,
+        mock_no_allowlist_config,
+    ):
+        """get_note succeeds without allowlist."""
+        from joplin_mcp.tools.notes import get_note
+
+        mock_note = MagicMock()
+        mock_note.parent_id = "nb_id"
+        mock_note.title = "Test Note"
+        mock_note.body = "content"
+        mock_note.id = "12345678901234567890123456789012"
+        mock_note.created_time = 1609459200000
+        mock_note.updated_time = 1609545600000
+        mock_note.is_todo = 0
+        mock_note.todo_completed = 0
+
+        mock_client = MagicMock()
+        mock_client.get_note.return_value = mock_note
+        mock_get_client.return_value = mock_client
+
+        fn = _get_tool_fn(get_note)
+        result = await fn(note_id="12345678901234567890123456789012")
+        assert result is not None
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes.get_joplin_client")
+    async def test_delete_note_works_without_allowlist(
+        self,
+        mock_get_client,
+        mock_no_allowlist_config,
+    ):
+        """delete_note succeeds without allowlist."""
+        from joplin_mcp.tools.notes import delete_note
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        fn = _get_tool_fn(delete_note)
+        result = await fn(note_id="12345678901234567890123456789012")
+        assert "SUCCESS" in result
+
+
+# === Error message tests (D7) ===
+
+
+class TestNoteAllowlistErrorMessages:
+    """Verify error messages are generic and do not leak notebook details."""
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes.validate_notebook_access")
+    @patch("joplin_mcp.tools.notes.get_joplin_client")
+    async def test_get_note_error_does_not_contain_notebook_id(
+        self,
+        mock_get_client,
+        mock_validate,
+        mock_allowlist_config,
+    ):
+        """Error message should not contain the notebook ID or name."""
+        from joplin_mcp.tools.notes import get_note
+
+        blocked_nb_id = "secret_private_nb_id_0000000000"
+        mock_note = MagicMock()
+        mock_note.parent_id = blocked_nb_id
+
+        mock_client = MagicMock()
+        mock_client.get_note.return_value = mock_note
+        mock_get_client.return_value = mock_client
+
+        mock_validate.side_effect = ValueError("Notebook not accessible")
+
+        fn = _get_tool_fn(get_note)
+        with pytest.raises(ValueError) as exc_info:
+            await fn(note_id="12345678901234567890123456789012")
+
+        error_msg = str(exc_info.value)
+        assert blocked_nb_id not in error_msg
+        assert "secret" not in error_msg.lower()
+        assert "private" not in error_msg.lower()
+        assert "Notebook not accessible" in error_msg
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes.validate_notebook_access")
+    @patch("joplin_mcp.tools.notes.get_notebook_id_by_name")
+    @patch("joplin_mcp.tools.notes.get_joplin_client")
+    async def test_create_note_error_does_not_contain_notebook_name(
+        self,
+        mock_get_client,
+        mock_get_nb_id,
+        mock_validate,
+        mock_allowlist_config,
+    ):
+        """Error message should not contain the target notebook name."""
+        from joplin_mcp.tools.notes import create_note
+
+        mock_get_nb_id.return_value = "some_nb_id"
+        mock_validate.side_effect = ValueError("Notebook not accessible")
+
+        fn = _get_tool_fn(create_note)
+        with pytest.raises(ValueError) as exc_info:
+            await fn(
+                title="Test",
+                notebook_name="My Private Diary",
+                body="content",
+            )
+
+        error_msg = str(exc_info.value)
+        assert "My Private Diary" not in error_msg
+        assert "Notebook not accessible" in error_msg
+
+
+# === Tests for get_links with allowlist ===
+
+
+class TestGetLinksAllowlist:
+    """Tests for get_links allowlist validation and filtering."""
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes.is_notebook_accessible")
+    @patch("joplin_mcp.tools.notes.validate_notebook_access")
+    @patch("joplin_mcp.tools.notes.get_joplin_client")
+    async def test_get_links_blocked_source_note(
+        self,
+        mock_get_client,
+        mock_validate,
+        mock_is_accessible,
+        mock_allowlist_config,
+    ):
+        """Should raise error when source note is in a non-allowlisted notebook."""
+        from joplin_mcp.tools.notes import get_links
+
+        mock_note = MagicMock()
+        mock_note.parent_id = "blocked_nb_id"
+        mock_note.title = "Secret Note"
+        mock_note.body = "some content"
+        mock_note.id = "12345678901234567890123456789012"
+        mock_client = MagicMock()
+        mock_client.get_note.return_value = mock_note
+        mock_get_client.return_value = mock_client
+
+        mock_validate.side_effect = ValueError("Notebook not accessible")
+
+        fn = _get_tool_fn(get_links)
+        with pytest.raises(ValueError, match="Notebook not accessible"):
+            await fn(note_id="12345678901234567890123456789012")
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes.process_search_results")
+    @patch("joplin_mcp.tools.notes.is_notebook_accessible")
+    @patch("joplin_mcp.tools.notes.validate_notebook_access")
+    @patch("joplin_mcp.tools.notes.get_joplin_client")
+    async def test_get_links_filters_inaccessible_linked_notes(
+        self,
+        mock_get_client,
+        mock_validate,
+        mock_is_accessible,
+        mock_search_results,
+        mock_allowlist_config,
+    ):
+        """Should filter out outgoing links to notes in non-accessible notebooks."""
+        from joplin_mcp.tools.notes import get_links
+
+        target_note_id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        blocked_note_id = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+        mock_note = MagicMock()
+        mock_note.parent_id = "allowed_nb_id"
+        mock_note.title = "Source Note"
+        mock_note.body = (
+            f"Link to [allowed](:/{target_note_id}) and [blocked](:/{blocked_note_id})"
+        )
+        mock_note.id = "12345678901234567890123456789012"
+
+        target_note = MagicMock()
+        target_note.id = target_note_id
+        target_note.title = "Allowed Target"
+        target_note.parent_id = "allowed_nb_id"
+
+        blocked_note = MagicMock()
+        blocked_note.id = blocked_note_id
+        blocked_note.title = "Blocked Target"
+        blocked_note.parent_id = "blocked_nb_id"
+
+        mock_client = MagicMock()
+        mock_client.get_note.side_effect = lambda nid, **kw: {
+            "12345678901234567890123456789012": mock_note,
+            target_note_id: target_note,
+            blocked_note_id: blocked_note,
+        }[nid]
+        mock_client.search_all.return_value = []
+        mock_get_client.return_value = mock_client
+        mock_search_results.return_value = []
+
+        # Source note passes validation; is_notebook_accessible controls link filtering
+        mock_validate.return_value = None
+        mock_is_accessible.side_effect = lambda nb_id, **kw: nb_id != "blocked_nb_id"
+
+        fn = _get_tool_fn(get_links)
+        result = await fn(note_id="12345678901234567890123456789012")
+
+        # The allowed link should appear, the blocked one should not
+        assert "Allowed Target" in result
+        assert "Blocked Target" not in result
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes.process_search_results")
+    @patch("joplin_mcp.tools.notes.is_notebook_accessible")
+    @patch("joplin_mcp.tools.notes.validate_notebook_access")
+    @patch("joplin_mcp.tools.notes.get_joplin_client")
+    async def test_get_links_filters_inaccessible_backlinks(
+        self,
+        mock_get_client,
+        mock_validate,
+        mock_is_accessible,
+        mock_search_results,
+        mock_allowlist_config,
+    ):
+        """Should filter out backlinks from notes in non-accessible notebooks."""
+        from joplin_mcp.tools.notes import get_links
+
+        note_id = "12345678901234567890123456789012"
+
+        mock_note = MagicMock()
+        mock_note.parent_id = "allowed_nb_id"
+        mock_note.title = "My Note"
+        mock_note.body = "no links here"
+        mock_note.id = note_id
+
+        # Backlink from an accessible notebook
+        allowed_backlink = MagicMock()
+        allowed_backlink.id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        allowed_backlink.title = "Allowed Backlink"
+        allowed_backlink.parent_id = "allowed_nb_id"
+        allowed_backlink.body = f"See [ref](:/{note_id})"
+
+        # Backlink from a blocked notebook
+        blocked_backlink = MagicMock()
+        blocked_backlink.id = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        blocked_backlink.title = "Blocked Backlink"
+        blocked_backlink.parent_id = "blocked_nb_id"
+        blocked_backlink.body = f"See [ref](:/{note_id})"
+
+        mock_client = MagicMock()
+        mock_client.get_note.return_value = mock_note
+        mock_client.search_all.return_value = []
+        mock_get_client.return_value = mock_client
+        mock_search_results.return_value = [allowed_backlink, blocked_backlink]
+
+        mock_validate.return_value = None
+        mock_is_accessible.side_effect = lambda nb_id, **kw: nb_id != "blocked_nb_id"
+
+        fn = _get_tool_fn(get_links)
+        result = await fn(note_id=note_id)
+
+        assert "Allowed Backlink" in result
+        assert "Blocked Backlink" not in result
+
+
+# === Tests for find_in_note with allowlist ===
+
+
+class TestFindInNoteAllowlist:
+    """Tests for find_in_note allowlist validation."""
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes.validate_notebook_access")
+    @patch("joplin_mcp.tools.notes.get_joplin_client")
+    async def test_find_in_note_blocked_notebook(
+        self,
+        mock_get_client,
+        mock_validate,
+        mock_allowlist_config,
+    ):
+        """Should raise error when note is in a non-allowlisted notebook."""
+        from joplin_mcp.tools.notes import find_in_note
+
+        mock_note = MagicMock()
+        mock_note.parent_id = "blocked_nb_id"
+        mock_note.title = "Secret Note"
+        mock_note.body = "secret content"
+        mock_note.id = "12345678901234567890123456789012"
+        mock_client = MagicMock()
+        mock_client.get_note.return_value = mock_note
+        mock_get_client.return_value = mock_client
+
+        mock_validate.side_effect = ValueError("Notebook not accessible")
+
+        fn = _get_tool_fn(find_in_note)
+        with pytest.raises(ValueError, match="Notebook not accessible"):
+            await fn(
+                note_id="12345678901234567890123456789012",
+                pattern="secret",
+            )
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes.get_notebook_map_cached")
+    @patch("joplin_mcp.tools.notes.validate_notebook_access")
+    @patch("joplin_mcp.tools.notes.get_joplin_client")
+    async def test_find_in_note_allowed_notebook(
+        self,
+        mock_get_client,
+        mock_validate,
+        mock_nb_map,
+        mock_allowlist_config,
+    ):
+        """Should succeed when note is in an allowlisted notebook."""
+        from joplin_mcp.tools.notes import find_in_note
+
+        mock_note = MagicMock()
+        mock_note.parent_id = "allowed_nb_id"
+        mock_note.title = "Public Note"
+        mock_note.body = "hello world"
+        mock_note.id = "12345678901234567890123456789012"
+        mock_note.created_time = 1609459200000
+        mock_note.updated_time = 1609545600000
+        mock_note.is_todo = 0
+        mock_client = MagicMock()
+        mock_client.get_note.return_value = mock_note
+        mock_get_client.return_value = mock_client
+        mock_nb_map.return_value = {}
+
+        mock_validate.return_value = None
+
+        fn = _get_tool_fn(find_in_note)
+        result = await fn(
+            note_id="12345678901234567890123456789012",
+            pattern="hello",
+        )
+
+        mock_validate.assert_called_once_with(
+            "allowed_nb_id",
+            allowlist_entries=mock_allowlist_config.notebook_allowlist,
+        )
+        assert "hello" in result

--- a/tests/test_tools_notes_allowlist.py
+++ b/tests/test_tools_notes_allowlist.py
@@ -740,6 +740,56 @@ class TestNoteAllowlistErrorMessages:
         assert "My Private Diary" not in error_msg
         assert "Notebook not accessible" in error_msg
 
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notes._module_config")
+    @patch(
+        "joplin_mcp.notebook_utils._module_config",
+        create=True,
+    )
+    @patch("joplin_mcp.fastmcp_server._module_config")
+    @patch("joplin_mcp.notebook_utils.get_notebook_map_cached")
+    @patch("joplin_mcp.tools.notes.get_joplin_client")
+    async def test_create_note_flat_unknown_name_does_not_leak_titles(
+        self,
+        mock_get_client,
+        mock_get_map,
+        mock_server_cfg,
+        mock_utils_cfg,
+        mock_notes_cfg,
+    ):
+        """create_note(notebook_name='X-not-real') under allowlist must not enumerate denied notebooks."""
+        from joplin_mcp.tools.notes import create_note
+
+        for cfg in (mock_server_cfg, mock_utils_cfg, mock_notes_cfg):
+            cfg.has_notebook_allowlist = True
+            cfg.notebook_allowlist = ["Work"]
+            cfg.should_show_content.return_value = True
+            cfg.should_show_full_content.return_value = True
+            cfg.get_max_preview_length.return_value = 300
+            cfg.is_smart_toc_enabled.return_value = False
+            cfg.get_smart_toc_threshold.return_value = 2000
+            cfg.tools = {}
+
+        mock_get_map.return_value = {
+            "work_id": {"title": "Work", "parent_id": None},
+            "secret_id": {"title": "Secrets", "parent_id": None},
+            "diary_id": {"title": "Diary", "parent_id": None},
+            "tax_id": {"title": "Tax", "parent_id": None},
+        }
+
+        fn = _get_tool_fn(create_note)
+        with pytest.raises(ValueError) as exc_info:
+            await fn(
+                title="Test",
+                notebook_name="anything-not-real",
+                body="content",
+            )
+
+        msg = str(exc_info.value)
+        for denied in ("Secrets", "Diary", "Tax"):
+            assert denied not in msg
+        assert "Available notebooks" not in msg
+
 
 # === Tests for get_links with allowlist ===
 

--- a/tests/test_tools_tags.py
+++ b/tests/test_tools_tags.py
@@ -195,49 +195,26 @@ NOTE_C = "c" * 32
 
 
 class TestTagNoteTool:
-    """Tests for tag_note tool (scalar and bulk paths)."""
+    """Tests for tag_note tool — all inputs use the aggregated report contract."""
 
     @pytest.mark.asyncio
-    @patch("joplin_mcp.tools.tags.get_tag_id_by_name")
     @patch("joplin_mcp.tools.tags.get_joplin_client")
-    async def test_scalar_preserves_single_op_format(
-        self, mock_get_client, mock_get_tag_id
-    ):
-        """Scalar + scalar returns the existing single-op success line unchanged."""
+    async def test_scalar_returns_one_row_report(self, mock_get_client):
+        """Scalar inputs go through the bulk path and produce a one-row report."""
         from joplin_mcp.tools.tags import tag_note
 
-        mock_note = MagicMock()
-        mock_note.title = "Test Note"
-
         mock_client = MagicMock()
-        mock_client.get_note.return_value = mock_note
+        mock_client.get_all_tags.return_value = [_make_tag("t1", "Work")]
         mock_get_client.return_value = mock_client
-        mock_get_tag_id.return_value = "tag_id_123"
 
         fn = _get_tool_fn(tag_note)
         result = await fn(note_id=NOTE_A, tag_name="Work")
 
-        mock_get_tag_id.assert_called_once_with("Work")
-        mock_client.add_tag_to_note.assert_called_once_with("tag_id_123", NOTE_A)
-        assert "tagged note" in result.lower()
-        assert "SUCCESS" in result
-        assert "TOTAL_OPS" not in result  # not the aggregated format
-
-    @pytest.mark.asyncio
-    @patch("joplin_mcp.tools.tags.get_joplin_client")
-    async def test_scalar_raises_when_note_not_found(self, mock_get_client):
-        """Scalar path raises ValueError with find_notes hint when note missing."""
-        from joplin_mcp.tools.tags import tag_note
-
-        mock_client = MagicMock()
-        mock_client.get_note.side_effect = Exception("Note not found")
-        mock_get_client.return_value = mock_client
-
-        fn = _get_tool_fn(tag_note)
-        with pytest.raises(ValueError) as exc_info:
-            await fn(note_id=NOTE_A, tag_name="Work")
-        assert "not found" in str(exc_info.value)
-        assert "find_notes" in str(exc_info.value)
+        mock_client.add_tag_to_note.assert_called_once_with("t1", NOTE_A)
+        assert "OPERATION: TAG_NOTE" in result
+        assert "TOTAL_OPS: 1" in result
+        assert "SUCCEEDED: 1" in result
+        assert "FAILED: 0" in result
 
     @pytest.mark.asyncio
     @patch("joplin_mcp.tools.tags.get_joplin_client")
@@ -482,22 +459,14 @@ class TestTagNoteTool:
         assert fline.count('"') == 4
 
     @pytest.mark.asyncio
-    @patch("joplin_mcp.tools.tags.get_tag_id_by_name")
     @patch("joplin_mcp.tools.tags.get_joplin_client")
-    async def test_scalar_path_propagates_missing_tag_error(
-        self, mock_get_client, mock_get_tag_id
-    ):
-        """Scalar path surfaces get_tag_id_by_name's ValueError when the tag is missing."""
+    async def test_scalar_missing_tag_raises_before_any_mutation(self, mock_get_client):
+        """Scalar input with an unknown tag still raises up-front via _resolve_tag_ids."""
         from joplin_mcp.tools.tags import tag_note
 
-        mock_note = MagicMock()
-        mock_note.title = "Test Note"
         mock_client = MagicMock()
-        mock_client.get_note.return_value = mock_note
+        mock_client.get_all_tags.return_value = [_make_tag("t1", "Work")]
         mock_get_client.return_value = mock_client
-        mock_get_tag_id.side_effect = ValueError(
-            "Tag 'Ghost' not found. Available tags: Work. Use create_tag to create a new tag."
-        )
 
         fn = _get_tool_fn(tag_note)
         with pytest.raises(ValueError) as exc_info:
@@ -512,46 +481,26 @@ class TestTagNoteTool:
 
 
 class TestUntagNoteTool:
-    """Tests for untag_note tool (scalar and bulk paths)."""
+    """Tests for untag_note tool — all inputs use the aggregated report contract."""
 
     @pytest.mark.asyncio
-    @patch("joplin_mcp.tools.tags.get_tag_id_by_name")
     @patch("joplin_mcp.tools.tags.get_joplin_client")
-    async def test_scalar_preserves_single_op_format(
-        self, mock_get_client, mock_get_tag_id
-    ):
-        """Scalar + scalar returns the existing single-op success line unchanged."""
+    async def test_scalar_returns_one_row_report(self, mock_get_client):
+        """Scalar inputs go through the bulk path and produce a one-row report."""
         from joplin_mcp.tools.tags import untag_note
 
-        mock_note = MagicMock()
-        mock_note.title = "Test Note"
         mock_client = MagicMock()
-        mock_client.get_note.return_value = mock_note
+        mock_client.get_all_tags.return_value = [_make_tag("t1", "Work")]
         mock_get_client.return_value = mock_client
-        mock_get_tag_id.return_value = "tag_id_789"
 
         fn = _get_tool_fn(untag_note)
         result = await fn(note_id=NOTE_A, tag_name="Work")
 
-        mock_client.delete.assert_called_once_with(f"/tags/tag_id_789/notes/{NOTE_A}")
-        assert "removed tag" in result.lower()
-        assert "SUCCESS" in result
-        assert "TOTAL_OPS" not in result
-
-    @pytest.mark.asyncio
-    @patch("joplin_mcp.tools.tags.get_joplin_client")
-    async def test_scalar_raises_when_note_not_found(self, mock_get_client):
-        """Scalar path raises ValueError with find_notes hint when note missing."""
-        from joplin_mcp.tools.tags import untag_note
-
-        mock_client = MagicMock()
-        mock_client.get_note.side_effect = Exception("Note not found")
-        mock_get_client.return_value = mock_client
-
-        fn = _get_tool_fn(untag_note)
-        with pytest.raises(ValueError) as exc_info:
-            await fn(note_id=NOTE_A, tag_name="Work")
-        assert "not found" in str(exc_info.value)
+        mock_client.delete.assert_called_once_with(f"/tags/t1/notes/{NOTE_A}")
+        assert "OPERATION: UNTAG_NOTE" in result
+        assert "TOTAL_OPS: 1" in result
+        assert "SUCCEEDED: 1" in result
+        assert "FAILED: 0" in result
 
     @pytest.mark.asyncio
     @patch("joplin_mcp.tools.tags.get_joplin_client")

--- a/tests/test_tools_tags_allowlist.py
+++ b/tests/test_tools_tags_allowlist.py
@@ -1,0 +1,330 @@
+"""Tests for tag tool allowlist enforcement."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _get_tool_fn(tool):
+    """Get the underlying function from a tool (handles both wrapped and unwrapped)."""
+    if hasattr(tool, "fn"):
+        return tool.fn
+    return tool
+
+
+# === Fixtures ===
+
+
+@pytest.fixture
+def mock_allowlist_config():
+    """Enable allowlist in _module_config for tag tools."""
+    with patch("joplin_mcp.tools.tags._module_config") as mock_cfg:
+        mock_cfg.has_notebook_allowlist = True
+        mock_cfg.notebook_allowlist = ["AI", "Projects/*"]
+        mock_cfg.tools = {}
+        yield mock_cfg
+
+
+@pytest.fixture
+def mock_no_allowlist_config():
+    """Explicitly disable allowlist in _module_config for backward compat tests."""
+    with patch("joplin_mcp.tools.tags._module_config") as mock_cfg:
+        mock_cfg.has_notebook_allowlist = False
+        mock_cfg.notebook_allowlist = None
+        mock_cfg.tools = {}
+        yield mock_cfg
+
+
+# === Tests for tag_note with allowlist ===
+
+
+class TestTagNoteAllowlist:
+    """Tests for tag_note allowlist validation."""
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.tags.validate_notebook_access")
+    @patch("joplin_mcp.tools.tags.get_tag_id_by_name")
+    @patch("joplin_mcp.tools.tags.get_joplin_client")
+    async def test_tag_note_allowlisted(
+        self,
+        mock_get_client,
+        mock_get_tag_id,
+        mock_validate,
+        mock_allowlist_config,
+    ):
+        """Should succeed when note is in an allowlisted notebook."""
+        from joplin_mcp.tools.tags import tag_note
+
+        mock_note = MagicMock()
+        mock_note.parent_id = "allowlisted_nb_id"
+        mock_note.title = "Test Note"
+
+        mock_client = MagicMock()
+        mock_client.get_note.return_value = mock_note
+        mock_get_client.return_value = mock_client
+        mock_get_tag_id.return_value = "tag_id_123"
+
+        fn = _get_tool_fn(tag_note)
+        result = await fn(
+            note_id="12345678901234567890123456789012", tag_name="Important"
+        )
+
+        mock_validate.assert_called_once_with(
+            "allowlisted_nb_id",
+            allowlist_entries=mock_allowlist_config.notebook_allowlist,
+        )
+        mock_client.add_tag_to_note.assert_called_once()
+        assert "SUCCESS" in result
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.tags.validate_notebook_access")
+    @patch("joplin_mcp.tools.tags.get_joplin_client")
+    async def test_tag_note_non_allowlisted(
+        self,
+        mock_get_client,
+        mock_validate,
+        mock_allowlist_config,
+    ):
+        """Should raise error when note is in a non-allowlisted notebook."""
+        from joplin_mcp.tools.tags import tag_note
+
+        mock_note = MagicMock()
+        mock_note.parent_id = "blocked_nb_id"
+        mock_note.title = "Secret Note"
+
+        mock_client = MagicMock()
+        mock_client.get_note.return_value = mock_note
+        mock_get_client.return_value = mock_client
+
+        mock_validate.side_effect = ValueError("Notebook not accessible")
+
+        fn = _get_tool_fn(tag_note)
+        with pytest.raises(ValueError, match="Notebook not accessible"):
+            await fn(
+                note_id="12345678901234567890123456789012", tag_name="Important"
+            )
+
+        mock_client.add_tag_to_note.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.tags.get_tag_id_by_name")
+    @patch("joplin_mcp.tools.tags.get_joplin_client")
+    async def test_tag_note_no_allowlist(
+        self,
+        mock_get_client,
+        mock_get_tag_id,
+        mock_no_allowlist_config,
+    ):
+        """Should succeed without allowlist checks when allowlist is disabled."""
+        from joplin_mcp.tools.tags import tag_note
+
+        mock_note = MagicMock()
+        mock_note.parent_id = "any_nb_id"
+        mock_note.title = "Test Note"
+
+        mock_client = MagicMock()
+        mock_client.get_note.return_value = mock_note
+        mock_get_client.return_value = mock_client
+        mock_get_tag_id.return_value = "tag_id_123"
+
+        fn = _get_tool_fn(tag_note)
+        result = await fn(
+            note_id="12345678901234567890123456789012", tag_name="Work"
+        )
+
+        mock_client.add_tag_to_note.assert_called_once()
+        assert "SUCCESS" in result
+
+
+# === Tests for untag_note with allowlist ===
+
+
+class TestUntagNoteAllowlist:
+    """Tests for untag_note allowlist validation."""
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.tags.validate_notebook_access")
+    @patch("joplin_mcp.tools.tags.get_tag_id_by_name")
+    @patch("joplin_mcp.tools.tags.get_joplin_client")
+    async def test_untag_note_allowlisted(
+        self,
+        mock_get_client,
+        mock_get_tag_id,
+        mock_validate,
+        mock_allowlist_config,
+    ):
+        """Should succeed when note is in an allowlisted notebook."""
+        from joplin_mcp.tools.tags import untag_note
+
+        mock_note = MagicMock()
+        mock_note.parent_id = "allowlisted_nb_id"
+        mock_note.title = "Test Note"
+
+        mock_client = MagicMock()
+        mock_client.get_note.return_value = mock_note
+        mock_get_client.return_value = mock_client
+        mock_get_tag_id.return_value = "tag_id_123"
+
+        fn = _get_tool_fn(untag_note)
+        result = await fn(
+            note_id="12345678901234567890123456789012", tag_name="Important"
+        )
+
+        mock_validate.assert_called_once_with(
+            "allowlisted_nb_id",
+            allowlist_entries=mock_allowlist_config.notebook_allowlist,
+        )
+        assert "SUCCESS" in result
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.tags.validate_notebook_access")
+    @patch("joplin_mcp.tools.tags.get_joplin_client")
+    async def test_untag_note_non_allowlisted(
+        self,
+        mock_get_client,
+        mock_validate,
+        mock_allowlist_config,
+    ):
+        """Should raise error when note is in a non-allowlisted notebook."""
+        from joplin_mcp.tools.tags import untag_note
+
+        mock_note = MagicMock()
+        mock_note.parent_id = "blocked_nb_id"
+        mock_note.title = "Secret Note"
+
+        mock_client = MagicMock()
+        mock_client.get_note.return_value = mock_note
+        mock_get_client.return_value = mock_client
+
+        mock_validate.side_effect = ValueError("Notebook not accessible")
+
+        fn = _get_tool_fn(untag_note)
+        with pytest.raises(ValueError, match="Notebook not accessible"):
+            await fn(
+                note_id="12345678901234567890123456789012", tag_name="Important"
+            )
+
+        mock_client.delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.tags.get_tag_id_by_name")
+    @patch("joplin_mcp.tools.tags.get_joplin_client")
+    async def test_untag_note_no_allowlist(
+        self,
+        mock_get_client,
+        mock_get_tag_id,
+        mock_no_allowlist_config,
+    ):
+        """Should succeed without allowlist checks when allowlist is disabled."""
+        from joplin_mcp.tools.tags import untag_note
+
+        mock_note = MagicMock()
+        mock_note.parent_id = "any_nb_id"
+        mock_note.title = "Test Note"
+
+        mock_client = MagicMock()
+        mock_client.get_note.return_value = mock_note
+        mock_get_client.return_value = mock_client
+        mock_get_tag_id.return_value = "tag_id_123"
+
+        fn = _get_tool_fn(untag_note)
+        result = await fn(
+            note_id="12345678901234567890123456789012", tag_name="Work"
+        )
+
+        assert "SUCCESS" in result
+
+
+# === Tests for get_tags_by_note with allowlist ===
+
+
+class TestGetTagsByNoteAllowlist:
+    """Tests for get_tags_by_note allowlist validation."""
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.tags.validate_notebook_access")
+    @patch("joplin_mcp.tools.tags.get_joplin_client")
+    async def test_get_tags_by_note_allowlisted(
+        self,
+        mock_get_client,
+        mock_validate,
+        mock_allowlist_config,
+    ):
+        """Should succeed when note is in an allowlisted notebook."""
+        from joplin_mcp.tools.tags import get_tags_by_note
+
+        mock_note = MagicMock()
+        mock_note.parent_id = "allowlisted_nb_id"
+
+        mock_tag = MagicMock()
+        mock_tag.title = "Work"
+        mock_tag.id = "tag_id_1"
+        mock_tag.created_time = 1609459200000
+        mock_tag.updated_time = 1609545600000
+
+        mock_client = MagicMock()
+        mock_client.get_note.return_value = mock_note
+        mock_client.get_tags.return_value = [mock_tag]
+        mock_get_client.return_value = mock_client
+
+        fn = _get_tool_fn(get_tags_by_note)
+        result = await fn(note_id="12345678901234567890123456789012")
+
+        mock_validate.assert_called_once_with(
+            "allowlisted_nb_id",
+            allowlist_entries=mock_allowlist_config.notebook_allowlist,
+        )
+        assert result is not None
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.tags.validate_notebook_access")
+    @patch("joplin_mcp.tools.tags.get_joplin_client")
+    async def test_get_tags_by_note_non_allowlisted(
+        self,
+        mock_get_client,
+        mock_validate,
+        mock_allowlist_config,
+    ):
+        """Should raise error when note is in a non-allowlisted notebook."""
+        from joplin_mcp.tools.tags import get_tags_by_note
+
+        mock_note = MagicMock()
+        mock_note.parent_id = "blocked_nb_id"
+
+        mock_client = MagicMock()
+        mock_client.get_note.return_value = mock_note
+        mock_get_client.return_value = mock_client
+
+        mock_validate.side_effect = ValueError("Notebook not accessible")
+
+        fn = _get_tool_fn(get_tags_by_note)
+        with pytest.raises(ValueError, match="Notebook not accessible"):
+            await fn(note_id="12345678901234567890123456789012")
+
+        mock_client.get_tags.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.tags.get_joplin_client")
+    async def test_get_tags_by_note_no_allowlist(
+        self,
+        mock_get_client,
+        mock_no_allowlist_config,
+    ):
+        """Should succeed without allowlist checks when allowlist is disabled."""
+        from joplin_mcp.tools.tags import get_tags_by_note
+
+        mock_tag = MagicMock()
+        mock_tag.title = "Work"
+        mock_tag.id = "tag_id_1"
+        mock_tag.created_time = 1609459200000
+        mock_tag.updated_time = 1609545600000
+
+        mock_client = MagicMock()
+        mock_client.get_tags.return_value = [mock_tag]
+        mock_get_client.return_value = mock_client
+
+        fn = _get_tool_fn(get_tags_by_note)
+        result = await fn(note_id="12345678901234567890123456789012")
+
+        mock_client.get_note.assert_not_called()
+        assert result is not None

--- a/tests/test_tools_tags_allowlist.py
+++ b/tests/test_tools_tags_allowlist.py
@@ -12,6 +12,13 @@ def _get_tool_fn(tool):
     return tool
 
 
+def _make_tag(tag_id: str, title: str):
+    tag = MagicMock()
+    tag.id = tag_id
+    tag.title = title
+    return tag
+
+
 # === Fixtures ===
 
 
@@ -43,12 +50,10 @@ class TestTagNoteAllowlist:
 
     @pytest.mark.asyncio
     @patch("joplin_mcp.tools.tags.validate_notebook_access")
-    @patch("joplin_mcp.tools.tags.get_tag_id_by_name")
     @patch("joplin_mcp.tools.tags.get_joplin_client")
     async def test_tag_note_allowlisted(
         self,
         mock_get_client,
-        mock_get_tag_id,
         mock_validate,
         mock_allowlist_config,
     ):
@@ -61,8 +66,8 @@ class TestTagNoteAllowlist:
 
         mock_client = MagicMock()
         mock_client.get_note.return_value = mock_note
+        mock_client.get_all_tags.return_value = [_make_tag("tag_id_123", "Important")]
         mock_get_client.return_value = mock_client
-        mock_get_tag_id.return_value = "tag_id_123"
 
         fn = _get_tool_fn(tag_note)
         result = await fn(
@@ -74,7 +79,9 @@ class TestTagNoteAllowlist:
             allowlist_entries=mock_allowlist_config.notebook_allowlist,
         )
         mock_client.add_tag_to_note.assert_called_once()
-        assert "SUCCESS" in result
+        assert "OPERATION: TAG_NOTE" in result
+        assert "SUCCEEDED: 1" in result
+        assert "FAILED: 0" in result
 
     @pytest.mark.asyncio
     @patch("joplin_mcp.tools.tags.validate_notebook_access")
@@ -85,8 +92,9 @@ class TestTagNoteAllowlist:
         mock_validate,
         mock_allowlist_config,
     ):
-        """Should raise error when note is in a non-allowlisted notebook."""
+        """Allowlist denial is captured in the report, not raised."""
         from joplin_mcp.tools.tags import tag_note
+        from joplin_mcp.notebook_utils import AllowlistDeniedError
 
         mock_note = MagicMock()
         mock_note.parent_id = "blocked_nb_id"
@@ -94,46 +102,45 @@ class TestTagNoteAllowlist:
 
         mock_client = MagicMock()
         mock_client.get_note.return_value = mock_note
+        mock_client.get_all_tags.return_value = [_make_tag("tag_id_123", "Important")]
         mock_get_client.return_value = mock_client
 
-        mock_validate.side_effect = ValueError("Notebook not accessible")
+        mock_validate.side_effect = AllowlistDeniedError("Notebook not accessible")
 
         fn = _get_tool_fn(tag_note)
-        with pytest.raises(ValueError, match="Notebook not accessible"):
-            await fn(
-                note_id="12345678901234567890123456789012", tag_name="Important"
-            )
+        result = await fn(
+            note_id="12345678901234567890123456789012", tag_name="Important"
+        )
 
         mock_client.add_tag_to_note.assert_not_called()
+        assert "OPERATION: TAG_NOTE" in result
+        assert "SUCCEEDED: 0" in result
+        assert "FAILED: 1" in result
+        assert "Notebook not accessible" in result
 
     @pytest.mark.asyncio
-    @patch("joplin_mcp.tools.tags.get_tag_id_by_name")
     @patch("joplin_mcp.tools.tags.get_joplin_client")
     async def test_tag_note_no_allowlist(
         self,
         mock_get_client,
-        mock_get_tag_id,
         mock_no_allowlist_config,
     ):
         """Should succeed without allowlist checks when allowlist is disabled."""
         from joplin_mcp.tools.tags import tag_note
 
-        mock_note = MagicMock()
-        mock_note.parent_id = "any_nb_id"
-        mock_note.title = "Test Note"
-
         mock_client = MagicMock()
-        mock_client.get_note.return_value = mock_note
+        mock_client.get_all_tags.return_value = [_make_tag("tag_id_123", "Work")]
         mock_get_client.return_value = mock_client
-        mock_get_tag_id.return_value = "tag_id_123"
 
         fn = _get_tool_fn(tag_note)
         result = await fn(
             note_id="12345678901234567890123456789012", tag_name="Work"
         )
 
+        # No allowlist → bulk path skips client.get_note entirely.
+        mock_client.get_note.assert_not_called()
         mock_client.add_tag_to_note.assert_called_once()
-        assert "SUCCESS" in result
+        assert "SUCCEEDED: 1" in result
 
 
 # === Tests for untag_note with allowlist ===
@@ -144,12 +151,10 @@ class TestUntagNoteAllowlist:
 
     @pytest.mark.asyncio
     @patch("joplin_mcp.tools.tags.validate_notebook_access")
-    @patch("joplin_mcp.tools.tags.get_tag_id_by_name")
     @patch("joplin_mcp.tools.tags.get_joplin_client")
     async def test_untag_note_allowlisted(
         self,
         mock_get_client,
-        mock_get_tag_id,
         mock_validate,
         mock_allowlist_config,
     ):
@@ -162,8 +167,8 @@ class TestUntagNoteAllowlist:
 
         mock_client = MagicMock()
         mock_client.get_note.return_value = mock_note
+        mock_client.get_all_tags.return_value = [_make_tag("tag_id_123", "Important")]
         mock_get_client.return_value = mock_client
-        mock_get_tag_id.return_value = "tag_id_123"
 
         fn = _get_tool_fn(untag_note)
         result = await fn(
@@ -174,7 +179,9 @@ class TestUntagNoteAllowlist:
             "allowlisted_nb_id",
             allowlist_entries=mock_allowlist_config.notebook_allowlist,
         )
-        assert "SUCCESS" in result
+        assert "OPERATION: UNTAG_NOTE" in result
+        assert "SUCCEEDED: 1" in result
+        assert "FAILED: 0" in result
 
     @pytest.mark.asyncio
     @patch("joplin_mcp.tools.tags.validate_notebook_access")
@@ -185,8 +192,9 @@ class TestUntagNoteAllowlist:
         mock_validate,
         mock_allowlist_config,
     ):
-        """Should raise error when note is in a non-allowlisted notebook."""
+        """Allowlist denial is captured in the report, not raised."""
         from joplin_mcp.tools.tags import untag_note
+        from joplin_mcp.notebook_utils import AllowlistDeniedError
 
         mock_note = MagicMock()
         mock_note.parent_id = "blocked_nb_id"
@@ -194,45 +202,45 @@ class TestUntagNoteAllowlist:
 
         mock_client = MagicMock()
         mock_client.get_note.return_value = mock_note
+        mock_client.get_all_tags.return_value = [_make_tag("tag_id_123", "Important")]
         mock_get_client.return_value = mock_client
 
-        mock_validate.side_effect = ValueError("Notebook not accessible")
+        mock_validate.side_effect = AllowlistDeniedError("Notebook not accessible")
 
         fn = _get_tool_fn(untag_note)
-        with pytest.raises(ValueError, match="Notebook not accessible"):
-            await fn(
-                note_id="12345678901234567890123456789012", tag_name="Important"
-            )
+        result = await fn(
+            note_id="12345678901234567890123456789012", tag_name="Important"
+        )
 
         mock_client.delete.assert_not_called()
+        assert "OPERATION: UNTAG_NOTE" in result
+        assert "SUCCEEDED: 0" in result
+        assert "FAILED: 1" in result
+        assert "Notebook not accessible" in result
 
     @pytest.mark.asyncio
-    @patch("joplin_mcp.tools.tags.get_tag_id_by_name")
     @patch("joplin_mcp.tools.tags.get_joplin_client")
     async def test_untag_note_no_allowlist(
         self,
         mock_get_client,
-        mock_get_tag_id,
         mock_no_allowlist_config,
     ):
         """Should succeed without allowlist checks when allowlist is disabled."""
         from joplin_mcp.tools.tags import untag_note
 
-        mock_note = MagicMock()
-        mock_note.parent_id = "any_nb_id"
-        mock_note.title = "Test Note"
-
         mock_client = MagicMock()
-        mock_client.get_note.return_value = mock_note
+        mock_client.get_all_tags.return_value = [_make_tag("tag_id_123", "Work")]
         mock_get_client.return_value = mock_client
-        mock_get_tag_id.return_value = "tag_id_123"
 
         fn = _get_tool_fn(untag_note)
         result = await fn(
             note_id="12345678901234567890123456789012", tag_name="Work"
         )
 
-        assert "SUCCESS" in result
+        # No allowlist → bulk path skips client.get_note entirely.
+        mock_client.get_note.assert_not_called()
+        mock_client.delete.assert_called_once()
+        assert "SUCCEEDED: 1" in result
 
 
 # === Tests for get_tags_by_note with allowlist ===


### PR DESCRIPTION
## Summary

Wire notebook allowlist checks into all tool handlers.

- Note tools: `get_note`, `create_note`, `update_note`, `edit_note`, `delete_note`, `find_notes`, `find_notes_with_tag`, `find_notes_in_notebook`, `get_all_notes`, `get_links`, `find_in_note`
- Notebook tools: `list_notebooks`, `create_notebook`, `update_notebook`, `delete_notebook`
- Tag tools: `tag_note`, `untag_note`, `get_tags_by_note` (including bulk operation paths)
- Add `_no_notebook_allowlist` autouse fixture in conftest for test isolation
- Add comprehensive unit and integration tests for all enforcement points

**PR 2 of 3** — Depends on alondmnt/joplin-mcp#25. E2E tests and docs follow in PR 3.