### PR TITLE
fix: validate create_notebook parent IDs strictly

### DIFF
--- a/skills/joplin/SKILL.md
+++ b/skills/joplin/SKILL.md
@@ -60,7 +60,7 @@ If you need to change a paragraph, fix a typo, or append a section: always use `
 | `note_id` | 32-char hex ID only |
 | `notebook_name` | Human-readable name (e.g., "Work") |
 | `tag_name` | Human-readable name (e.g., "important") |
-| `parent_id` | 32-char hex ID of parent notebook |
+| `parent_id` | Omit for top-level notebooks, or pass a 32-char hex parent notebook ID only |
 
 Search results return IDs — use those IDs in subsequent calls.
 
@@ -84,6 +84,7 @@ edit_note(id, old_string="...", new_string="...")  # surgical edit
 ### Create a sub-notebook with notes
 
 ```
+create_notebook("Sub")              # top-level notebook: omit parent_id
 list_notebooks()                      # find parent notebook ID
 create_notebook("Sub", parent_id="<parent_hex_id>")
 create_note("Title", notebook_name="Sub", body="...")

--- a/src/joplin_mcp/tools/notebooks.py
+++ b/src/joplin_mcp/tools/notebooks.py
@@ -15,11 +15,31 @@ from joplin_mcp.fastmcp_server import (
     format_update_success,
     get_joplin_client,
     invalidate_notebook_map_cache,
+    validate_joplin_id,
 )
 from joplin_mcp.notebook_utils import (
     filter_accessible_notebooks,
     validate_notebook_access,
 )
+
+
+PARENT_ID_ERROR = "parent_id must be null or a valid notebook ID"
+
+
+def _normalize_parent_id(parent_id: Optional[str]) -> Optional[str]:
+    """Validate optional notebook parent IDs for top-level/sub-notebook creation."""
+    if parent_id is None:
+        return None
+
+    normalized = parent_id.strip()
+    if not normalized:
+        raise ValueError(PARENT_ID_ERROR)
+
+    try:
+        return validate_joplin_id(normalized)
+    except ValueError as exc:
+        raise ValueError(PARENT_ID_ERROR) from exc
+
 
 # === NOTEBOOK TOOLS ===
 
@@ -47,7 +67,7 @@ async def list_notebooks() -> str:
 async def create_notebook(
     title: Annotated[RequiredStringType, Field(description="Notebook title")],
     parent_id: Annotated[
-        Optional[str], Field(description="Parent notebook ID (optional)")
+        Optional[JoplinIdType], Field(description="Parent notebook ID (optional)")
     ] = None,
 ) -> str:
     """Create a new notebook (folder) in Joplin to organize your notes.
@@ -63,10 +83,12 @@ async def create_notebook(
         - create_notebook("2024 Projects", "work_notebook_id") - Create a sub-notebook
     """
 
+    normalized_parent_id = _normalize_parent_id(parent_id)
+
     if _module_config.has_notebook_allowlist:
-        if parent_id:
+        if normalized_parent_id:
             validate_notebook_access(
-                parent_id.strip(),
+                normalized_parent_id,
                 allowlist_entries=_module_config.notebook_allowlist,
             )
         else:
@@ -74,8 +96,8 @@ async def create_notebook(
 
     client = get_joplin_client()
     notebook_kwargs = {"title": title}
-    if parent_id:
-        notebook_kwargs["parent_id"] = parent_id.strip()
+    if normalized_parent_id:
+        notebook_kwargs["parent_id"] = normalized_parent_id
 
     notebook = client.add_notebook(**notebook_kwargs)
     # Invalidate notebook path cache to reflect new structure immediately

--- a/src/joplin_mcp/tools/notebooks.py
+++ b/src/joplin_mcp/tools/notebooks.py
@@ -1,7 +1,7 @@
 """Notebook tools for Joplin MCP."""
 from typing import Annotated, Optional
 
-from pydantic import Field
+from pydantic import AfterValidator, Field, StringConstraints
 
 from joplin_mcp.fastmcp_server import (
     ItemType,
@@ -23,14 +23,14 @@ from joplin_mcp.notebook_utils import (
 )
 
 
-PARENT_ID_ERROR = "parent_id must be null or a valid notebook ID"
+PARENT_ID_ERROR = (
+    "parent_id must be omitted for a top-level notebook, or be a "
+    "32-character lowercase hex parent notebook ID"
+)
 
 
-def _normalize_parent_id(parent_id: Optional[str]) -> Optional[str]:
-    """Validate optional notebook parent IDs for top-level/sub-notebook creation."""
-    if parent_id is None:
-        return None
-
+def _validate_parent_notebook_id(parent_id: str) -> str:
+    """Validate parent notebook IDs after Pydantic has normalized them."""
     normalized = parent_id.strip()
     if not normalized:
         raise ValueError(PARENT_ID_ERROR)
@@ -39,6 +39,13 @@ def _normalize_parent_id(parent_id: Optional[str]) -> Optional[str]:
         return validate_joplin_id(normalized)
     except ValueError as exc:
         raise ValueError(PARENT_ID_ERROR) from exc
+
+
+ParentNotebookIdType = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, min_length=32, max_length=32),
+    AfterValidator(_validate_parent_notebook_id),
+]
 
 
 # === NOTEBOOK TOOLS ===
@@ -67,7 +74,8 @@ async def list_notebooks() -> str:
 async def create_notebook(
     title: Annotated[RequiredStringType, Field(description="Notebook title")],
     parent_id: Annotated[
-        Optional[JoplinIdType], Field(description="Parent notebook ID (optional)")
+        Optional[ParentNotebookIdType],
+        Field(description="Parent notebook ID (optional)"),
     ] = None,
 ) -> str:
     """Create a new notebook (folder) in Joplin to organize your notes.
@@ -80,10 +88,10 @@ async def create_notebook(
 
     Examples:
         - create_notebook("Work Projects") - Create a top-level notebook
-        - create_notebook("2024 Projects", "work_notebook_id") - Create a sub-notebook
+        - create_notebook("2024 Projects", "0123456789abcdef0123456789abcdef") - Create a sub-notebook
     """
 
-    normalized_parent_id = _normalize_parent_id(parent_id)
+    normalized_parent_id = parent_id.strip() if parent_id is not None else None
 
     if _module_config.has_notebook_allowlist:
         if normalized_parent_id:

--- a/tests/test_tools_notebooks.py
+++ b/tests/test_tools_notebooks.py
@@ -86,13 +86,13 @@ class TestCreateNotebookTool:
         fn = _get_tool_fn(create_notebook)
         result = await fn(
             title="Sub Notebook",
-            parent_id="parent_id_12345"
+            parent_id="12345678901234567890123456789012"
         )
 
         mock_client.add_notebook.assert_called_once()
         call_kwargs = mock_client.add_notebook.call_args[1]
         assert call_kwargs["title"] == "Sub Notebook"
-        assert call_kwargs["parent_id"] == "parent_id_12345"
+        assert call_kwargs["parent_id"] == "12345678901234567890123456789012"
         assert "SUCCESS" in result
 
     @pytest.mark.asyncio
@@ -123,10 +123,30 @@ class TestCreateNotebookTool:
         mock_get_client.return_value = mock_client
 
         fn = _get_tool_fn(create_notebook)
-        await fn(title="Test", parent_id="  parent_id  ")
+        await fn(title="Test", parent_id=" 12345678901234567890123456789012 ")
 
         call_kwargs = mock_client.add_notebook.call_args[1]
-        assert call_kwargs["parent_id"] == "parent_id"
+        assert call_kwargs["parent_id"] == "12345678901234567890123456789012"
+
+    @pytest.mark.asyncio
+    async def test_rejects_string_null_parent_id(self):
+        """Should reject the literal string 'null' as parent_id."""
+        from joplin_mcp.tools.notebooks import create_notebook
+
+        fn = _get_tool_fn(create_notebook)
+
+        with pytest.raises(ValueError):
+            await fn(title="Bad Notebook", parent_id="null")
+
+    @pytest.mark.asyncio
+    async def test_rejects_blank_parent_id(self):
+        """Should reject blank parent_id values instead of treating them as valid."""
+        from joplin_mcp.tools.notebooks import create_notebook
+
+        fn = _get_tool_fn(create_notebook)
+
+        with pytest.raises(ValueError, match="parent_id must be null or a valid notebook ID"):
+            await fn(title="Bad Notebook", parent_id="   ")
 
 
 # === Tests for update_notebook tool ===

--- a/tests/test_tools_notebooks.py
+++ b/tests/test_tools_notebooks.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pydantic import ValidationError
 
 
 def _get_tool_fn(tool):
@@ -122,8 +123,9 @@ class TestCreateNotebookTool:
         mock_client.add_notebook.return_value = "nb_id"
         mock_get_client.return_value = mock_client
 
-        fn = _get_tool_fn(create_notebook)
-        await fn(title="Test", parent_id=" 12345678901234567890123456789012 ")
+        await create_notebook.run(
+            {"title": "Test", "parent_id": " 12345678901234567890123456789012 "}
+        )
 
         call_kwargs = mock_client.add_notebook.call_args[1]
         assert call_kwargs["parent_id"] == "12345678901234567890123456789012"
@@ -133,20 +135,49 @@ class TestCreateNotebookTool:
         """Should reject the literal string 'null' as parent_id."""
         from joplin_mcp.tools.notebooks import create_notebook
 
-        fn = _get_tool_fn(create_notebook)
-
-        with pytest.raises(ValueError):
-            await fn(title="Bad Notebook", parent_id="null")
+        with pytest.raises(ValidationError, match="at least 32 characters"):
+            await create_notebook.run({"title": "Bad Notebook", "parent_id": "null"})
 
     @pytest.mark.asyncio
     async def test_rejects_blank_parent_id(self):
         """Should reject blank parent_id values instead of treating them as valid."""
         from joplin_mcp.tools.notebooks import create_notebook
 
-        fn = _get_tool_fn(create_notebook)
+        with pytest.raises(ValidationError, match="at least 32 characters"):
+            await create_notebook.run({"title": "Bad Notebook", "parent_id": "   "})
 
-        with pytest.raises(ValueError, match="parent_id must be null or a valid notebook ID"):
-            await fn(title="Bad Notebook", parent_id="   ")
+    @pytest.mark.asyncio
+    async def test_rejects_non_hex_parent_id(self):
+        """Should reject 32-char parent IDs that are not valid hex."""
+        from joplin_mcp.tools.notebooks import create_notebook
+
+        with pytest.raises(
+            ValidationError,
+            match="parent_id must be omitted for a top-level notebook",
+        ):
+            await create_notebook.run(
+                {
+                    "title": "Bad Notebook",
+                    "parent_id": "g2345678901234567890123456789012",
+                }
+            )
+
+    @pytest.mark.asyncio
+    @patch("joplin_mcp.tools.notebooks.invalidate_notebook_map_cache")
+    @patch("joplin_mcp.tools.notebooks.get_joplin_client")
+    async def test_accepts_explicit_null_parent_id(
+        self, mock_get_client, mock_invalidate
+    ):
+        """Should allow explicit null parent_id values via the MCP tool path."""
+        from joplin_mcp.tools.notebooks import create_notebook
+
+        mock_client = MagicMock()
+        mock_client.add_notebook.return_value = "nb_id"
+        mock_get_client.return_value = mock_client
+
+        await create_notebook.run({"title": "Top Level Notebook", "parent_id": None})
+
+        mock_client.add_notebook.assert_called_once_with(title="Top Level Notebook")
 
 
 # === Tests for update_notebook tool ===

--- a/tests/test_tools_notebooks_allowlist.py
+++ b/tests/test_tools_notebooks_allowlist.py
@@ -159,10 +159,12 @@ class TestCreateNotebookAllowlist:
         mock_get_client.return_value = mock_client
 
         fn = _get_tool_fn(create_notebook)
-        result = await fn(title="Sub Notebook", parent_id="allowlisted_parent_id")
+        result = await fn(
+            title="Sub Notebook", parent_id="12345678901234567890123456789012"
+        )
 
         mock_validate.assert_called_once_with(
-            "allowlisted_parent_id",
+            "12345678901234567890123456789012",
             allowlist_entries=mock_allowlist_config.notebook_allowlist,
         )
         mock_client.add_notebook.assert_called_once()
@@ -186,7 +188,9 @@ class TestCreateNotebookAllowlist:
 
         fn = _get_tool_fn(create_notebook)
         with pytest.raises(ValueError, match="Notebook not accessible"):
-            await fn(title="Bad Notebook", parent_id="blocked_parent_id")
+            await fn(
+                title="Bad Notebook", parent_id="12345678901234567890123456789012"
+            )
 
         # Verify error message is generic (D7) -- no notebook details leaked
         mock_validate.assert_called_once()


### PR DESCRIPTION
## Summary
- validate `create_notebook.parent_id` strictly: omit it for top-level notebooks, or pass a valid 32-char Joplin notebook ID
- reject invalid placeholder strings such as `"null"` instead of forwarding them to Joplin
- add regression coverage for invalid `parent_id` inputs and update the Joplin skill guidance to show the correct top-level notebook call shape

## Root cause
`create_notebook` accepted any truthy string for `parent_id` and forwarded it to `POST /folders`. If a client sent `"null"` as a string instead of JSON `null` or omission, that malformed value was passed through to Joplin.

## Additional context
This was observed during agent-driven MCP usage, where a smaller model emitted `parent_id: "null"` instead of omitting the field, corrupting the created notebook in Joplin's DB. This PR hardens the server contract so malformed inputs are rejected early.

## Testing
- `uv run --extra dev python -m pytest tests/test_tools_notebooks.py tests/test_tools_notebooks_allowlist.py`