### PR TITLE
test: tighten e2e allowlist suite

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,5 +1,6 @@
 """E2E test fixtures for real Joplin instance testing."""
 
+import logging
 import os
 import time
 from unittest.mock import patch
@@ -8,6 +9,8 @@ import pytest
 from joppy.client_api import ClientApi
 
 from joplin_mcp.config import JoplinMCPConfig
+
+logger = logging.getLogger(__name__)
 
 
 def _joplin_reachable(client: ClientApi) -> bool:
@@ -140,30 +143,45 @@ def e2e_cleanup(e2e_client):
             if note.id not in pre_notes:
                 try:
                     e2e_client.delete_note(note.id)
-                except Exception:
-                    pass
+                except Exception as exc:
+                    logger.warning(
+                        "e2e_cleanup: failed to delete note id=%s title=%r: %s",
+                        note.id, getattr(note, "title", "?"), exc,
+                    )
 
         # Delete tags
         for tag in e2e_client.get_all_tags():
             if tag.id not in pre_tags:
                 try:
                     e2e_client.delete_tag(tag.id)
-                except Exception:
-                    pass
+                except Exception as exc:
+                    logger.warning(
+                        "e2e_cleanup: failed to delete tag id=%s title=%r: %s",
+                        tag.id, getattr(tag, "title", "?"), exc,
+                    )
 
         # Delete notebooks (may need multiple passes for nested ones)
+        last_errors: dict[str, str] = {}
         for _ in range(3):
             remaining = False
             for nb in e2e_client.get_all_notebooks():
                 if nb.id not in pre_notebooks:
                     try:
                         e2e_client.delete_notebook(nb.id)
-                    except Exception:
+                        last_errors.pop(nb.id, None)
+                    except Exception as exc:
                         remaining = True
+                        last_errors[nb.id] = (
+                            f"title={getattr(nb, 'title', '?')!r}: {exc}"
+                        )
             if not remaining:
                 break
-    except Exception:
-        pass  # Joplin may be temporarily unavailable
+        for nb_id, detail in last_errors.items():
+            logger.warning(
+                "e2e_cleanup: failed to delete notebook id=%s %s", nb_id, detail
+            )
+    except Exception as exc:
+        logger.warning("e2e_cleanup: aborted with %s", exc)
 
     # Invalidate cache so next test starts fresh
     invalidate_notebook_map_cache()

--- a/tests/e2e/test_e2e_allowlist.py
+++ b/tests/e2e/test_e2e_allowlist.py
@@ -209,12 +209,14 @@ class TestListNotebooksAllowlist:
 class TestCreateNoteAllowlist:
 
     @pytest.mark.asyncio
-    async def test_create_in_allowed_notebook(self, hierarchy):
+    async def test_create_in_allowed_notebook(self, hierarchy, e2e_client):
         from joplin_mcp.tools.notes import create_note
 
         with _allowlist_config(["E2ETest_AI"]):
             r = await _call(create_note, title="Allowed", notebook_name="E2ETest_AI", body="ok")
             assert "Allowed" in r
+            nid = _extract_id(r)
+            assert e2e_client.get_note(nid, fields="id,parent_id").parent_id == hierarchy["E2ETest_AI"]
 
     @pytest.mark.asyncio
     async def test_create_in_blocked_notebook_raises(self, hierarchy):
@@ -225,13 +227,15 @@ class TestCreateNoteAllowlist:
                 await _call(create_note, title="Nope", notebook_name="E2ETest_Personal", body="no")
 
     @pytest.mark.asyncio
-    async def test_create_in_child_of_allowed_parent(self, hierarchy):
+    async def test_create_in_child_of_allowed_parent(self, hierarchy, e2e_client):
         """Allowlisting 'Projects' should allow creating notes in 'Work'."""
         from joplin_mcp.tools.notes import create_note
 
         with _allowlist_config(["E2ETest_Projects"]):
             r = await _call(create_note, title="Child OK", notebook_name="E2ETest_Work", body="ok")
             assert "Child OK" in r
+            nid = _extract_id(r)
+            assert e2e_client.get_note(nid, fields="id,parent_id").parent_id == hierarchy["E2ETest_Work"]
 
     @pytest.mark.asyncio
     async def test_create_in_child_of_blocked_parent(self, hierarchy):
@@ -280,7 +284,7 @@ class TestGetNoteAllowlist:
 class TestUpdateNoteAllowlist:
 
     @pytest.mark.asyncio
-    async def test_update_allowed_note(self, hierarchy):
+    async def test_update_allowed_note(self, hierarchy, e2e_client):
         from joplin_mcp.tools.notes import create_note, get_note, update_note
 
         r = await _call(create_note, title="Editable", notebook_name="E2ETest_AI", body="v1")
@@ -290,6 +294,8 @@ class TestUpdateNoteAllowlist:
             await _call(update_note, note_id=nid, title="Edited", body="v2")
             result = await _call(get_note, note_id=nid)
             assert "Edited" in result
+            # update_note must not relocate the note out of its notebook
+            assert e2e_client.get_note(nid, fields="id,parent_id").parent_id == hierarchy["E2ETest_AI"]
 
     @pytest.mark.asyncio
     async def test_update_blocked_note_raises(self, hierarchy):
@@ -310,7 +316,7 @@ class TestUpdateNoteAllowlist:
 class TestEditNoteAllowlist:
 
     @pytest.mark.asyncio
-    async def test_edit_allowed_note(self, hierarchy):
+    async def test_edit_allowed_note(self, hierarchy, e2e_client):
         from joplin_mcp.tools.notes import create_note, edit_note, get_note
 
         r = await _call(create_note, title="EditMe", notebook_name="E2ETest_AI", body="hello world")
@@ -320,6 +326,8 @@ class TestEditNoteAllowlist:
             await _call(edit_note, note_id=nid, old_string="hello", new_string="goodbye")
             result = await _call(get_note, note_id=nid)
             assert "goodbye world" in result
+            # edit_note must not relocate the note out of its notebook
+            assert e2e_client.get_note(nid, fields="id,parent_id").parent_id == hierarchy["E2ETest_AI"]
 
     @pytest.mark.asyncio
     async def test_edit_blocked_note_raises(self, hierarchy):
@@ -425,12 +433,14 @@ class TestFindNotesInNotebookAllowlist:
 class TestCreateNotebookAllowlist:
 
     @pytest.mark.asyncio
-    async def test_create_sub_notebook_in_allowed_parent(self, hierarchy):
+    async def test_create_sub_notebook_in_allowed_parent(self, hierarchy, e2e_client):
         from joplin_mcp.tools.notebooks import create_notebook
 
         with _allowlist_config(["E2ETest_Projects"]):
             r = await _call(create_notebook, title="New Sub", parent_id=hierarchy["E2ETest_Projects"])
             assert "New Sub" in r
+            nb_id = _extract_id(r)
+            assert e2e_client.get_notebook(nb_id, fields="id,parent_id").parent_id == hierarchy["E2ETest_Projects"]
 
     @pytest.mark.asyncio
     async def test_create_sub_notebook_in_blocked_parent_raises(self, hierarchy):
@@ -469,12 +479,14 @@ class TestHierarchicalAccess:
             assert "Deep Note" in result
 
     @pytest.mark.asyncio
-    async def test_parent_allowlist_grants_child_note_write(self, hierarchy):
+    async def test_parent_allowlist_grants_child_note_write(self, hierarchy, e2e_client):
         from joplin_mcp.tools.notes import create_note
 
         with _allowlist_config(["E2ETest_Projects"]):
             r = await _call(create_note, title="Work Note", notebook_name="E2ETest_Work", body="ok")
             assert "Work Note" in r
+            nid = _extract_id(r)
+            assert e2e_client.get_note(nid, fields="id,parent_id").parent_id == hierarchy["E2ETest_Work"]
 
     @pytest.mark.asyncio
     async def test_child_allowlist_does_not_grant_parent(self, hierarchy):
@@ -493,13 +505,15 @@ class TestHierarchicalAccess:
 class TestNegationPatterns:
 
     @pytest.mark.asyncio
-    async def test_negation_excludes_child(self, hierarchy):
+    async def test_negation_excludes_child(self, hierarchy, e2e_client):
         """'Projects' + '!Projects/Secret' should block Secret but allow Work."""
         from joplin_mcp.tools.notes import create_note
 
         with _allowlist_config(["E2ETest_Projects", "!E2ETest_Projects/E2ETest_Secret"]):
             r = await _call(create_note, title="OK", notebook_name="E2ETest_Work", body="ok")
             assert "OK" in r
+            nid = _extract_id(r)
+            assert e2e_client.get_note(nid, fields="id,parent_id").parent_id == hierarchy["E2ETest_Work"]
 
             with pytest.raises(Exception):
                 await _call(create_note, title="No", notebook_name="E2ETest_Secret", body="no")
@@ -569,12 +583,13 @@ class TestErrorMessagePrivacy:
 class TestTagsWithAllowlist:
 
     @pytest.mark.asyncio
-    async def test_tag_note_in_allowed_notebook(self, hierarchy):
+    async def test_tag_note_in_allowed_notebook(self, hierarchy, e2e_client):
         from joplin_mcp.tools.notes import create_note
         from joplin_mcp.tools.tags import create_tag, get_tags_by_note, tag_note
 
         r = await _call(create_note, title="TagTarget", notebook_name="E2ETest_AI", body="x")
         nid = _extract_id(r)
+        assert e2e_client.get_note(nid, fields="id,parent_id").parent_id == hierarchy["E2ETest_AI"]
         await _call(create_tag, title="e2e-al-tag")
 
         with _allowlist_config(["E2ETest_AI"]):
@@ -597,12 +612,13 @@ class TestTagsWithAllowlist:
                 await _call(tag_note, note_id=nid, tag_name="e2e-al-blocked-tag")
 
     @pytest.mark.asyncio
-    async def test_untag_note_in_allowed_notebook(self, hierarchy):
+    async def test_untag_note_in_allowed_notebook(self, hierarchy, e2e_client):
         from joplin_mcp.tools.notes import create_note
         from joplin_mcp.tools.tags import create_tag, tag_note, untag_note
 
         r = await _call(create_note, title="UntagTarget", notebook_name="E2ETest_AI", body="x")
         nid = _extract_id(r)
+        assert e2e_client.get_note(nid, fields="id,parent_id").parent_id == hierarchy["E2ETest_AI"]
         await _call(create_tag, title="e2e-al-untag")
         await _call(tag_note, note_id=nid, tag_name="e2e-al-untag")
 
@@ -646,7 +662,7 @@ class TestTagsWithAllowlist:
 class TestMixedPatterns:
 
     @pytest.mark.asyncio
-    async def test_exact_plus_glob_plus_negation(self, hierarchy):
+    async def test_exact_plus_glob_plus_negation(self, hierarchy, e2e_client):
         """Combine 'AI' (exact) + 'Projects/*' (glob) + '!Projects/Secret' (negate)."""
         from joplin_mcp.tools.notebooks import list_notebooks
         from joplin_mcp.tools.notes import create_note
@@ -661,9 +677,13 @@ class TestMixedPatterns:
             # Can create in allowed notebooks
             r = await _call(create_note, title="MixedOK", notebook_name="E2ETest_AI", body="ok")
             assert "MixedOK" in r
+            nid = _extract_id(r)
+            assert e2e_client.get_note(nid, fields="id,parent_id").parent_id == hierarchy["E2ETest_AI"]
 
             r2 = await _call(create_note, title="MixedOK2", notebook_name="E2ETest_Work", body="ok")
             assert "MixedOK2" in r2
+            nid2 = _extract_id(r2)
+            assert e2e_client.get_note(nid2, fields="id,parent_id").parent_id == hierarchy["E2ETest_Work"]
 
             # Blocked notebooks
             with pytest.raises(Exception):

--- a/tests/e2e/test_e2e_allowlist.py
+++ b/tests/e2e/test_e2e_allowlist.py
@@ -5,7 +5,9 @@ enforcement with actual Joplin API calls. Module configuration is patched for
 test isolation, but the Joplin API itself is never mocked.
 """
 
+import asyncio
 import re
+import time
 from contextlib import contextmanager
 from unittest.mock import patch
 
@@ -36,6 +38,29 @@ def _extract_id(tool_output: str) -> str:
         return m.group(1)
     raise AssertionError(
         f"Could not extract Joplin ID from tool output: {tool_output!r}"
+    )
+
+
+async def _wait_for_search(tool, *, expected: str, timeout: float = 15.0, **kwargs) -> str:
+    """Poll an FTS-backed search tool until ``expected`` appears in its output.
+
+    Joplin's FTS index lags note/tag mutations by several seconds, so tools
+    that go through ``client.search_all`` (find_notes, find_notes_with_tag,
+    and get_links' backlink resolver) can return empty immediately after a
+    create or tag. Without this wait, negative assertions like
+    ``assert "X" not in result`` would pass trivially on an empty result and
+    silently hide a broken allowlist filter.
+    """
+    deadline = time.monotonic() + timeout
+    last = ""
+    while time.monotonic() < deadline:
+        last = await _call(tool, **kwargs)
+        if expected in last:
+            return last
+        await asyncio.sleep(0.5)
+    raise AssertionError(
+        f"Timed out after {timeout}s waiting for {expected!r} in search output. "
+        f"Last output: {last!r}"
     )
 
 
@@ -294,7 +319,6 @@ class TestUpdateNoteAllowlist:
             await _call(update_note, note_id=nid, title="Edited", body="v2")
             result = await _call(get_note, note_id=nid)
             assert "Edited" in result
-            # update_note must not relocate the note out of its notebook
             assert e2e_client.get_note(nid, fields="id,parent_id").parent_id == hierarchy["E2ETest_AI"]
 
     @pytest.mark.asyncio
@@ -326,7 +350,6 @@ class TestEditNoteAllowlist:
             await _call(edit_note, note_id=nid, old_string="hello", new_string="goodbye")
             result = await _call(get_note, note_id=nid)
             assert "goodbye world" in result
-            # edit_note must not relocate the note out of its notebook
             assert e2e_client.get_note(nid, fields="id,parent_id").parent_id == hierarchy["E2ETest_AI"]
 
     @pytest.mark.asyncio
@@ -690,3 +713,190 @@ class TestMixedPatterns:
                 await _call(create_note, title="No", notebook_name="E2ETest_Secret", body="no")
             with pytest.raises(Exception):
                 await _call(create_note, title="No", notebook_name="E2ETest_Personal", body="no")
+
+
+# ===================================================================
+# 17. FIND NOTES WITH TAG — search result filtering
+# ===================================================================
+
+class TestFindNotesWithTagAllowlist:
+    """find_notes_with_tag must filter out notes in inaccessible notebooks."""
+
+    @pytest.mark.asyncio
+    async def test_returns_only_notes_in_allowed_notebooks(self, hierarchy):
+        from joplin_mcp.tools.notes import create_note, find_notes_with_tag
+        from joplin_mcp.tools.tags import create_tag, tag_note
+
+        r_allow = await _call(create_note, title="TaggedAllow", notebook_name="E2ETest_AI", body="x")
+        r_block = await _call(create_note, title="TaggedBlock", notebook_name="E2ETest_Personal", body="x")
+        nid_allow = _extract_id(r_allow)
+        nid_block = _extract_id(r_block)
+        await _call(create_tag, title="e2e-fnwt")
+        await _call(tag_note, note_id=nid_allow, tag_name="e2e-fnwt")
+        await _call(tag_note, note_id=nid_block, tag_name="e2e-fnwt")
+
+        # Wait for Joplin's FTS index to catch up so the blocked note would
+        # appear without filtering — otherwise the negative assertion would
+        # pass trivially on an empty result.
+        await _wait_for_search(find_notes_with_tag, expected="TaggedAllow", tag_name="e2e-fnwt")
+        await _wait_for_search(find_notes_with_tag, expected="TaggedBlock", tag_name="e2e-fnwt")
+
+        with _allowlist_config(["E2ETest_AI"]):
+            result = await _call(find_notes_with_tag, tag_name="e2e-fnwt")
+            assert "TaggedAllow" in result
+            assert "TaggedBlock" not in result
+
+    @pytest.mark.asyncio
+    async def test_returns_nothing_when_all_tagged_notes_blocked(self, hierarchy):
+        from joplin_mcp.tools.notes import create_note, find_notes_with_tag
+        from joplin_mcp.tools.tags import create_tag, tag_note
+
+        r = await _call(create_note, title="TaggedHidden", notebook_name="E2ETest_Personal", body="x")
+        nid = _extract_id(r)
+        await _call(create_tag, title="e2e-fnwt-hidden")
+        await _call(tag_note, note_id=nid, tag_name="e2e-fnwt-hidden")
+
+        # Wait for indexing so the assertion isn't a trivial empty-result pass.
+        await _wait_for_search(find_notes_with_tag, expected="TaggedHidden", tag_name="e2e-fnwt-hidden")
+
+        with _allowlist_config(["E2ETest_AI"]):
+            result = await _call(find_notes_with_tag, tag_name="e2e-fnwt-hidden")
+            assert "TaggedHidden" not in result
+
+
+# ===================================================================
+# 18. FIND IN NOTE — single-note regex search
+# ===================================================================
+
+class TestFindInNoteAllowlist:
+    """find_in_note must enforce allowlist on the target note's notebook."""
+
+    @pytest.mark.asyncio
+    async def test_find_in_allowed_note(self, hierarchy):
+        from joplin_mcp.tools.notes import create_note, find_in_note
+
+        r = await _call(create_note, title="FINAllowed", notebook_name="E2ETest_AI", body="hello target world")
+        nid = _extract_id(r)
+
+        with _allowlist_config(["E2ETest_AI"]):
+            result = await _call(find_in_note, note_id=nid, pattern="target")
+            assert "target" in result
+
+    @pytest.mark.asyncio
+    async def test_find_in_blocked_note_raises(self, hierarchy):
+        from joplin_mcp.tools.notes import create_note, find_in_note
+
+        r = await _call(create_note, title="FINBlocked", notebook_name="E2ETest_Personal", body="secret target value")
+        nid = _extract_id(r)
+
+        with _allowlist_config(["E2ETest_AI"]):
+            with pytest.raises(Exception):
+                await _call(find_in_note, note_id=nid, pattern="target")
+
+
+# ===================================================================
+# 19. GET ALL NOTES — full-listing filtering
+# ===================================================================
+
+class TestGetAllNotesAllowlist:
+    """get_all_notes must filter out notes in inaccessible notebooks."""
+
+    @pytest.mark.asyncio
+    async def test_returns_only_notes_in_allowed_notebooks(self, hierarchy):
+        from joplin_mcp.tools.notes import create_note, get_all_notes
+
+        await _call(create_note, title="GANVisible", notebook_name="E2ETest_AI", body="x")
+        await _call(create_note, title="GANHidden", notebook_name="E2ETest_Personal", body="x")
+
+        with _allowlist_config(["E2ETest_AI"]):
+            result = await _call(get_all_notes, limit=100)
+            assert "GANVisible" in result
+            assert "GANHidden" not in result
+
+    @pytest.mark.asyncio
+    async def test_returns_nothing_when_all_blocked(self, hierarchy):
+        from joplin_mcp.tools.notes import create_note, get_all_notes
+
+        await _call(create_note, title="GANOnlyHidden", notebook_name="E2ETest_Personal", body="x")
+
+        with _allowlist_config(["E2ETest_AI"]):
+            result = await _call(get_all_notes, limit=100)
+            assert "GANOnlyHidden" not in result
+
+
+# ===================================================================
+# 20. GET LINKS — outgoing-link + backlink filtering
+# ===================================================================
+
+class TestGetLinksAllowlist:
+    """get_links must deny the source note when blocked, and filter both
+    outgoing-link targets and backlinks that live in inaccessible notebooks."""
+
+    @pytest.mark.asyncio
+    async def test_get_links_from_allowed_source(self, hierarchy):
+        from joplin_mcp.tools.notes import create_note, get_links
+
+        target_r = await _call(create_note, title="GLTarget", notebook_name="E2ETest_AI", body="dst")
+        target_id = _extract_id(target_r)
+        source_r = await _call(
+            create_note,
+            title="GLSource",
+            notebook_name="E2ETest_AI",
+            body=f"see [t](:/{target_id})",
+        )
+        source_id = _extract_id(source_r)
+
+        with _allowlist_config(["E2ETest_AI"]):
+            result = await _call(get_links, note_id=source_id)
+            assert "GLTarget" in result
+
+    @pytest.mark.asyncio
+    async def test_get_links_from_blocked_source_raises(self, hierarchy):
+        from joplin_mcp.tools.notes import create_note, get_links
+
+        r = await _call(create_note, title="GLBlockedSource", notebook_name="E2ETest_Personal", body="x")
+        nid = _extract_id(r)
+
+        with _allowlist_config(["E2ETest_AI"]):
+            with pytest.raises(Exception):
+                await _call(get_links, note_id=nid)
+
+    @pytest.mark.asyncio
+    async def test_get_links_filters_blocked_outgoing_target(self, hierarchy):
+        from joplin_mcp.tools.notes import create_note, get_links
+
+        hidden_r = await _call(create_note, title="GLHiddenTarget", notebook_name="E2ETest_Personal", body="x")
+        hidden_id = _extract_id(hidden_r)
+        source_r = await _call(
+            create_note,
+            title="GLMixedSource",
+            notebook_name="E2ETest_AI",
+            body=f"link [h](:/{hidden_id})",
+        )
+        source_id = _extract_id(source_r)
+
+        with _allowlist_config(["E2ETest_AI"]):
+            result = await _call(get_links, note_id=source_id)
+            assert "GLHiddenTarget" not in result
+
+    @pytest.mark.asyncio
+    async def test_get_links_filters_blocked_backlinks(self, hierarchy):
+        from joplin_mcp.tools.notes import create_note, find_notes, get_links
+
+        target_r = await _call(create_note, title="GLBacklinkTarget", notebook_name="E2ETest_AI", body="x")
+        target_id = _extract_id(target_r)
+        await _call(
+            create_note,
+            title="GLHiddenBacklinker",
+            notebook_name="E2ETest_Personal",
+            body=f"refers [t](:/{target_id})",
+        )
+
+        # Backlinks are resolved via search_all, which is gated by Joplin's
+        # FTS index. Wait until the backlink would surface without filtering
+        # so the negative assertion isn't a trivial empty-result pass.
+        await _wait_for_search(find_notes, expected="GLHiddenBacklinker", query=f":/{target_id}")
+
+        with _allowlist_config(["E2ETest_AI"]):
+            result = await _call(get_links, note_id=target_id)
+            assert "GLHiddenBacklinker" not in result

--- a/tests/e2e/test_e2e_allowlist.py
+++ b/tests/e2e/test_e2e_allowlist.py
@@ -70,13 +70,15 @@ def _allowlist_config(allowlist, token="e2e_test_token"):
 def hierarchy(e2e_client):
     """Create a notebook hierarchy once for all allowlist tests.
 
-    Structure:
-        Projects/
-            Work/
-            Secret/
-        Personal/
-            Diary/
-        AI/
+    Structure (all titles prefixed with ``E2ETest_`` so they cannot collide
+    with notebooks the developer already has in their Joplin instance):
+
+        E2ETest_Projects/
+            E2ETest_Work/
+            E2ETest_Secret/
+        E2ETest_Personal/
+            E2ETest_Diary/
+        E2ETest_AI/
 
     Returns dict of {name: id}.  Uses e2e_client directly (not tool functions)
     to avoid allowlist/cache interference.  Created once per module, cleaned up
@@ -90,13 +92,17 @@ def hierarchy(e2e_client):
     created_ids = []  # track creation order for cleanup
 
     # Top-level
-    for name in ("Projects", "Personal", "AI"):
+    for name in ("E2ETest_Projects", "E2ETest_Personal", "E2ETest_AI"):
         nb_id = e2e_client.add_notebook(title=name)
         ids[name] = nb_id
         created_ids.append(nb_id)
 
     # Children
-    for name, parent in [("Work", "Projects"), ("Secret", "Projects"), ("Diary", "Personal")]:
+    for name, parent in [
+        ("E2ETest_Work", "E2ETest_Projects"),
+        ("E2ETest_Secret", "E2ETest_Projects"),
+        ("E2ETest_Diary", "E2ETest_Personal"),
+    ]:
         nb_id = e2e_client.add_notebook(title=name, parent_id=ids[parent])
         ids[name] = nb_id
         created_ids.append(nb_id)
@@ -139,14 +145,14 @@ class TestNoAllowlist:
         from joplin_mcp.tools.notebooks import list_notebooks
 
         listing = await _call(list_notebooks)
-        for name in ("Projects", "Work", "Secret", "Personal", "Diary", "AI"):
+        for name in ("E2ETest_Projects", "E2ETest_Work", "E2ETest_Secret", "E2ETest_Personal", "E2ETest_Diary", "E2ETest_AI"):
             assert name in listing
 
     @pytest.mark.asyncio
     async def test_note_crud_unrestricted(self, hierarchy):
         from joplin_mcp.tools.notes import create_note, get_note, delete_note
 
-        r = await _call(create_note, title="Free Note", notebook_name="Projects/Secret", body="x")
+        r = await _call(create_note, title="Free Note", notebook_name="E2ETest_Projects/E2ETest_Secret", body="x")
         nid = _extract_id(r)
         get_r = await _call(get_note, note_id=nid)
         assert "Free Note" in get_r
@@ -163,26 +169,26 @@ class TestListNotebooksAllowlist:
     async def test_only_allowed_notebooks_shown(self, hierarchy):
         from joplin_mcp.tools.notebooks import list_notebooks
 
-        with _allowlist_config(["AI", "Projects"]):
+        with _allowlist_config(["E2ETest_AI", "E2ETest_Projects"]):
             listing = await _call(list_notebooks)
-            assert "AI" in listing
-            assert "Projects" in listing
-            assert "Personal" not in listing
-            assert "Diary" not in listing
+            assert "E2ETest_AI" in listing
+            assert "E2ETest_Projects" in listing
+            assert "E2ETest_Personal" not in listing
+            assert "E2ETest_Diary" not in listing
 
     @pytest.mark.asyncio
     async def test_hierarchical_access_shows_children(self, hierarchy):
         """Allowlisting 'Projects' should also show its children."""
         from joplin_mcp.tools.notebooks import list_notebooks
 
-        with _allowlist_config(["Projects"]):
+        with _allowlist_config(["E2ETest_Projects"]):
             listing = await _call(list_notebooks)
-            assert "Projects" in listing
-            assert "Work" in listing
-            assert "Secret" in listing
+            assert "E2ETest_Projects" in listing
+            assert "E2ETest_Work" in listing
+            assert "E2ETest_Secret" in listing
             # Other top-level notebooks excluded
-            assert "Personal" not in listing
-            assert "AI" not in listing
+            assert "E2ETest_Personal" not in listing
+            assert "E2ETest_AI" not in listing
 
     @pytest.mark.asyncio
     async def test_empty_allowlist_denies_all_notebooks(self, hierarchy):
@@ -192,7 +198,7 @@ class TestListNotebooksAllowlist:
         with _allowlist_config([]):
             listing = await _call(list_notebooks)
             # Empty allowlist = deny all = no notebooks visible
-            for name in ("Projects", "Work", "Secret", "Personal", "Diary", "AI"):
+            for name in ("E2ETest_Projects", "E2ETest_Work", "E2ETest_Secret", "E2ETest_Personal", "E2ETest_Diary", "E2ETest_AI"):
                 assert name not in listing
 
 
@@ -206,34 +212,34 @@ class TestCreateNoteAllowlist:
     async def test_create_in_allowed_notebook(self, hierarchy):
         from joplin_mcp.tools.notes import create_note
 
-        with _allowlist_config(["AI"]):
-            r = await _call(create_note, title="Allowed", notebook_name="AI", body="ok")
+        with _allowlist_config(["E2ETest_AI"]):
+            r = await _call(create_note, title="Allowed", notebook_name="E2ETest_AI", body="ok")
             assert "Allowed" in r
 
     @pytest.mark.asyncio
     async def test_create_in_blocked_notebook_raises(self, hierarchy):
         from joplin_mcp.tools.notes import create_note
 
-        with _allowlist_config(["AI"]):
+        with _allowlist_config(["E2ETest_AI"]):
             with pytest.raises(Exception):
-                await _call(create_note, title="Nope", notebook_name="Personal", body="no")
+                await _call(create_note, title="Nope", notebook_name="E2ETest_Personal", body="no")
 
     @pytest.mark.asyncio
     async def test_create_in_child_of_allowed_parent(self, hierarchy):
         """Allowlisting 'Projects' should allow creating notes in 'Work'."""
         from joplin_mcp.tools.notes import create_note
 
-        with _allowlist_config(["Projects"]):
-            r = await _call(create_note, title="Child OK", notebook_name="Work", body="ok")
+        with _allowlist_config(["E2ETest_Projects"]):
+            r = await _call(create_note, title="Child OK", notebook_name="E2ETest_Work", body="ok")
             assert "Child OK" in r
 
     @pytest.mark.asyncio
     async def test_create_in_child_of_blocked_parent(self, hierarchy):
         from joplin_mcp.tools.notes import create_note
 
-        with _allowlist_config(["AI"]):
+        with _allowlist_config(["E2ETest_AI"]):
             with pytest.raises(Exception):
-                await _call(create_note, title="No", notebook_name="Diary", body="no")
+                await _call(create_note, title="No", notebook_name="E2ETest_Diary", body="no")
 
 
 # ===================================================================
@@ -247,10 +253,10 @@ class TestGetNoteAllowlist:
         from joplin_mcp.tools.notes import create_note, get_note
 
         # Create note without allowlist
-        r = await _call(create_note, title="Readable", notebook_name="AI", body="content")
+        r = await _call(create_note, title="Readable", notebook_name="E2ETest_AI", body="content")
         nid = _extract_id(r)
 
-        with _allowlist_config(["AI"]):
+        with _allowlist_config(["E2ETest_AI"]):
             result = await _call(get_note, note_id=nid)
             assert "Readable" in result
             assert "content" in result
@@ -259,10 +265,10 @@ class TestGetNoteAllowlist:
     async def test_get_blocked_note_raises(self, hierarchy):
         from joplin_mcp.tools.notes import create_note, get_note
 
-        r = await _call(create_note, title="Hidden", notebook_name="Personal", body="secret")
+        r = await _call(create_note, title="Hidden", notebook_name="E2ETest_Personal", body="secret")
         nid = _extract_id(r)
 
-        with _allowlist_config(["AI"]):
+        with _allowlist_config(["E2ETest_AI"]):
             with pytest.raises(Exception):
                 await _call(get_note, note_id=nid)
 
@@ -277,10 +283,10 @@ class TestUpdateNoteAllowlist:
     async def test_update_allowed_note(self, hierarchy):
         from joplin_mcp.tools.notes import create_note, get_note, update_note
 
-        r = await _call(create_note, title="Editable", notebook_name="AI", body="v1")
+        r = await _call(create_note, title="Editable", notebook_name="E2ETest_AI", body="v1")
         nid = _extract_id(r)
 
-        with _allowlist_config(["AI"]):
+        with _allowlist_config(["E2ETest_AI"]):
             await _call(update_note, note_id=nid, title="Edited", body="v2")
             result = await _call(get_note, note_id=nid)
             assert "Edited" in result
@@ -289,10 +295,10 @@ class TestUpdateNoteAllowlist:
     async def test_update_blocked_note_raises(self, hierarchy):
         from joplin_mcp.tools.notes import create_note, update_note
 
-        r = await _call(create_note, title="Locked", notebook_name="Personal", body="v1")
+        r = await _call(create_note, title="Locked", notebook_name="E2ETest_Personal", body="v1")
         nid = _extract_id(r)
 
-        with _allowlist_config(["AI"]):
+        with _allowlist_config(["E2ETest_AI"]):
             with pytest.raises(Exception):
                 await _call(update_note, note_id=nid, title="Nope")
 
@@ -307,10 +313,10 @@ class TestEditNoteAllowlist:
     async def test_edit_allowed_note(self, hierarchy):
         from joplin_mcp.tools.notes import create_note, edit_note, get_note
 
-        r = await _call(create_note, title="EditMe", notebook_name="AI", body="hello world")
+        r = await _call(create_note, title="EditMe", notebook_name="E2ETest_AI", body="hello world")
         nid = _extract_id(r)
 
-        with _allowlist_config(["AI"]):
+        with _allowlist_config(["E2ETest_AI"]):
             await _call(edit_note, note_id=nid, old_string="hello", new_string="goodbye")
             result = await _call(get_note, note_id=nid)
             assert "goodbye world" in result
@@ -319,10 +325,10 @@ class TestEditNoteAllowlist:
     async def test_edit_blocked_note_raises(self, hierarchy):
         from joplin_mcp.tools.notes import create_note, edit_note
 
-        r = await _call(create_note, title="NoEdit", notebook_name="Personal", body="text")
+        r = await _call(create_note, title="NoEdit", notebook_name="E2ETest_Personal", body="text")
         nid = _extract_id(r)
 
-        with _allowlist_config(["AI"]):
+        with _allowlist_config(["E2ETest_AI"]):
             with pytest.raises(Exception):
                 await _call(edit_note, note_id=nid, old_string="text", new_string="nope")
 
@@ -337,10 +343,10 @@ class TestDeleteNoteAllowlist:
     async def test_delete_allowed_note(self, hierarchy, e2e_client):
         from joplin_mcp.tools.notes import create_note, delete_note
 
-        r = await _call(create_note, title="Deletable", notebook_name="AI", body="bye")
+        r = await _call(create_note, title="Deletable", notebook_name="E2ETest_AI", body="bye")
         nid = _extract_id(r)
 
-        with _allowlist_config(["AI"]):
+        with _allowlist_config(["E2ETest_AI"]):
             result = await _call(delete_note, note_id=nid)
             assert "delete" in result.lower() or "success" in result.lower()
 
@@ -348,10 +354,10 @@ class TestDeleteNoteAllowlist:
     async def test_delete_blocked_note_raises(self, hierarchy):
         from joplin_mcp.tools.notes import create_note, delete_note
 
-        r = await _call(create_note, title="Protected", notebook_name="Personal", body="x")
+        r = await _call(create_note, title="Protected", notebook_name="E2ETest_Personal", body="x")
         nid = _extract_id(r)
 
-        with _allowlist_config(["AI"]):
+        with _allowlist_config(["E2ETest_AI"]):
             with pytest.raises(Exception):
                 await _call(delete_note, note_id=nid)
 
@@ -368,10 +374,10 @@ class TestFindNotesAllowlist:
         from joplin_mcp.tools.notes import create_note, find_notes
 
         # Create notes in allowed and blocked notebooks
-        await _call(create_note, title="VisibleSearchNote", notebook_name="AI", body="x")
-        await _call(create_note, title="HiddenSearchNote", notebook_name="Personal", body="x")
+        await _call(create_note, title="VisibleSearchNote", notebook_name="E2ETest_AI", body="x")
+        await _call(create_note, title="HiddenSearchNote", notebook_name="E2ETest_Personal", body="x")
 
-        with _allowlist_config(["AI"]):
+        with _allowlist_config(["E2ETest_AI"]):
             result = await _call(find_notes, query="*")
             assert "VisibleSearchNote" in result
             assert "HiddenSearchNote" not in result
@@ -380,9 +386,9 @@ class TestFindNotesAllowlist:
     async def test_list_all_returns_nothing_when_all_blocked(self, hierarchy):
         from joplin_mcp.tools.notes import create_note, find_notes
 
-        await _call(create_note, title="GhostSearchNote", notebook_name="Personal", body="x")
+        await _call(create_note, title="GhostSearchNote", notebook_name="E2ETest_Personal", body="x")
 
-        with _allowlist_config(["AI"]):
+        with _allowlist_config(["E2ETest_AI"]):
             result = await _call(find_notes, query="*")
             assert "GhostSearchNote" not in result
 
@@ -397,19 +403,19 @@ class TestFindNotesInNotebookAllowlist:
     async def test_find_in_allowed_notebook(self, hierarchy):
         from joplin_mcp.tools.notes import create_note, find_notes_in_notebook
 
-        await _call(create_note, title="InAI", notebook_name="AI", body="something")
+        await _call(create_note, title="InAI", notebook_name="E2ETest_AI", body="something")
 
-        with _allowlist_config(["AI"]):
-            result = await _call(find_notes_in_notebook, notebook_name="AI")
+        with _allowlist_config(["E2ETest_AI"]):
+            result = await _call(find_notes_in_notebook, notebook_name="E2ETest_AI")
             assert "InAI" in result
 
     @pytest.mark.asyncio
     async def test_find_in_blocked_notebook_raises(self, hierarchy):
         from joplin_mcp.tools.notes import find_notes_in_notebook
 
-        with _allowlist_config(["AI"]):
+        with _allowlist_config(["E2ETest_AI"]):
             with pytest.raises(Exception):
-                await _call(find_notes_in_notebook, notebook_name="Personal")
+                await _call(find_notes_in_notebook, notebook_name="E2ETest_Personal")
 
 
 # ===================================================================
@@ -422,24 +428,24 @@ class TestCreateNotebookAllowlist:
     async def test_create_sub_notebook_in_allowed_parent(self, hierarchy):
         from joplin_mcp.tools.notebooks import create_notebook
 
-        with _allowlist_config(["Projects"]):
-            r = await _call(create_notebook, title="New Sub", parent_id=hierarchy["Projects"])
+        with _allowlist_config(["E2ETest_Projects"]):
+            r = await _call(create_notebook, title="New Sub", parent_id=hierarchy["E2ETest_Projects"])
             assert "New Sub" in r
 
     @pytest.mark.asyncio
     async def test_create_sub_notebook_in_blocked_parent_raises(self, hierarchy):
         from joplin_mcp.tools.notebooks import create_notebook
 
-        with _allowlist_config(["AI"]):
+        with _allowlist_config(["E2ETest_AI"]):
             with pytest.raises(Exception):
-                await _call(create_notebook, title="Nope", parent_id=hierarchy["Personal"])
+                await _call(create_notebook, title="Nope", parent_id=hierarchy["E2ETest_Personal"])
 
     @pytest.mark.asyncio
     async def test_create_top_level_notebook_blocked(self, hierarchy):
         """With allowlist active, creating top-level notebooks is blocked."""
         from joplin_mcp.tools.notebooks import create_notebook
 
-        with _allowlist_config(["AI"]):
+        with _allowlist_config(["E2ETest_AI"]):
             with pytest.raises(Exception):
                 await _call(create_notebook, title="Top Level Nope")
 
@@ -455,10 +461,10 @@ class TestHierarchicalAccess:
         """Allowlisting 'Projects' should let us read notes in 'Work'."""
         from joplin_mcp.tools.notes import create_note, get_note
 
-        r = await _call(create_note, title="Deep Note", notebook_name="Work", body="deep")
+        r = await _call(create_note, title="Deep Note", notebook_name="E2ETest_Work", body="deep")
         nid = _extract_id(r)
 
-        with _allowlist_config(["Projects"]):
+        with _allowlist_config(["E2ETest_Projects"]):
             result = await _call(get_note, note_id=nid)
             assert "Deep Note" in result
 
@@ -466,8 +472,8 @@ class TestHierarchicalAccess:
     async def test_parent_allowlist_grants_child_note_write(self, hierarchy):
         from joplin_mcp.tools.notes import create_note
 
-        with _allowlist_config(["Projects"]):
-            r = await _call(create_note, title="Work Note", notebook_name="Work", body="ok")
+        with _allowlist_config(["E2ETest_Projects"]):
+            r = await _call(create_note, title="Work Note", notebook_name="E2ETest_Work", body="ok")
             assert "Work Note" in r
 
     @pytest.mark.asyncio
@@ -475,9 +481,9 @@ class TestHierarchicalAccess:
         """Allowlisting 'Work' should NOT grant access to sibling 'Secret'."""
         from joplin_mcp.tools.notes import create_note
 
-        with _allowlist_config(["Projects/Work"]):
+        with _allowlist_config(["E2ETest_Projects/E2ETest_Work"]):
             with pytest.raises(Exception):
-                await _call(create_note, title="No", notebook_name="Secret", body="no")
+                await _call(create_note, title="No", notebook_name="E2ETest_Secret", body="no")
 
 
 # ===================================================================
@@ -491,21 +497,21 @@ class TestNegationPatterns:
         """'Projects' + '!Projects/Secret' should block Secret but allow Work."""
         from joplin_mcp.tools.notes import create_note
 
-        with _allowlist_config(["Projects", "!Projects/Secret"]):
-            r = await _call(create_note, title="OK", notebook_name="Work", body="ok")
+        with _allowlist_config(["E2ETest_Projects", "!E2ETest_Projects/E2ETest_Secret"]):
+            r = await _call(create_note, title="OK", notebook_name="E2ETest_Work", body="ok")
             assert "OK" in r
 
             with pytest.raises(Exception):
-                await _call(create_note, title="No", notebook_name="Secret", body="no")
+                await _call(create_note, title="No", notebook_name="E2ETest_Secret", body="no")
 
     @pytest.mark.asyncio
     async def test_negation_in_listing(self, hierarchy):
         from joplin_mcp.tools.notebooks import list_notebooks
 
-        with _allowlist_config(["Projects", "!Projects/Secret"]):
+        with _allowlist_config(["E2ETest_Projects", "!E2ETest_Projects/E2ETest_Secret"]):
             listing = await _call(list_notebooks)
-            assert "Work" in listing
-            assert "Secret" not in listing
+            assert "E2ETest_Work" in listing
+            assert "E2ETest_Secret" not in listing
 
 
 # ===================================================================
@@ -519,19 +525,19 @@ class TestGlobPatterns:
         """'Projects/*' should match direct children Work and Secret."""
         from joplin_mcp.tools.notebooks import list_notebooks
 
-        with _allowlist_config(["Projects/*"]):
+        with _allowlist_config(["E2ETest_Projects/*"]):
             listing = await _call(list_notebooks)
-            assert "Work" in listing
-            assert "Secret" in listing
+            assert "E2ETest_Work" in listing
+            assert "E2ETest_Secret" in listing
 
     @pytest.mark.asyncio
     async def test_wildcard_with_negation(self, hierarchy):
         from joplin_mcp.tools.notebooks import list_notebooks
 
-        with _allowlist_config(["Projects/*", "!Projects/Secret"]):
+        with _allowlist_config(["E2ETest_Projects/*", "!E2ETest_Projects/E2ETest_Secret"]):
             listing = await _call(list_notebooks)
-            assert "Work" in listing
-            assert "Secret" not in listing
+            assert "E2ETest_Work" in listing
+            assert "E2ETest_Secret" not in listing
 
 
 # ===================================================================
@@ -545,15 +551,15 @@ class TestErrorMessagePrivacy:
         """Blocked access should raise a generic error without notebook info."""
         from joplin_mcp.tools.notes import create_note
 
-        with _allowlist_config(["AI"]):
+        with _allowlist_config(["E2ETest_AI"]):
             with pytest.raises(Exception) as exc_info:
-                await _call(create_note, title="X", notebook_name="Personal", body="x")
+                await _call(create_note, title="X", notebook_name="E2ETest_Personal", body="x")
 
             error_msg = str(exc_info.value).lower()
             # Should contain generic denial
             assert "not accessible" in error_msg
             # Should NOT contain the blocked notebook name or ID
-            assert hierarchy["Personal"].lower() not in error_msg
+            assert hierarchy["E2ETest_Personal"].lower() not in error_msg
 
 
 # ===================================================================
@@ -567,11 +573,11 @@ class TestTagsWithAllowlist:
         from joplin_mcp.tools.notes import create_note
         from joplin_mcp.tools.tags import create_tag, get_tags_by_note, tag_note
 
-        r = await _call(create_note, title="TagTarget", notebook_name="AI", body="x")
+        r = await _call(create_note, title="TagTarget", notebook_name="E2ETest_AI", body="x")
         nid = _extract_id(r)
         await _call(create_tag, title="e2e-al-tag")
 
-        with _allowlist_config(["AI"]):
+        with _allowlist_config(["E2ETest_AI"]):
             await _call(tag_note, note_id=nid, tag_name="e2e-al-tag")
             tags = await _call(get_tags_by_note, note_id=nid)
             assert "e2e-al-tag" in tags
@@ -582,11 +588,11 @@ class TestTagsWithAllowlist:
         from joplin_mcp.tools.notes import create_note
         from joplin_mcp.tools.tags import create_tag, tag_note
 
-        r = await _call(create_note, title="BlockedTagTarget", notebook_name="Personal", body="x")
+        r = await _call(create_note, title="BlockedTagTarget", notebook_name="E2ETest_Personal", body="x")
         nid = _extract_id(r)
         await _call(create_tag, title="e2e-al-blocked-tag")
 
-        with _allowlist_config(["AI"]):
+        with _allowlist_config(["E2ETest_AI"]):
             with pytest.raises(Exception):
                 await _call(tag_note, note_id=nid, tag_name="e2e-al-blocked-tag")
 
@@ -595,12 +601,12 @@ class TestTagsWithAllowlist:
         from joplin_mcp.tools.notes import create_note
         from joplin_mcp.tools.tags import create_tag, tag_note, untag_note
 
-        r = await _call(create_note, title="UntagTarget", notebook_name="AI", body="x")
+        r = await _call(create_note, title="UntagTarget", notebook_name="E2ETest_AI", body="x")
         nid = _extract_id(r)
         await _call(create_tag, title="e2e-al-untag")
         await _call(tag_note, note_id=nid, tag_name="e2e-al-untag")
 
-        with _allowlist_config(["AI"]):
+        with _allowlist_config(["E2ETest_AI"]):
             result = await _call(untag_note, note_id=nid, tag_name="e2e-al-untag")
             assert "success" in result.lower()
 
@@ -610,12 +616,12 @@ class TestTagsWithAllowlist:
         from joplin_mcp.tools.notes import create_note
         from joplin_mcp.tools.tags import create_tag, tag_note, untag_note
 
-        r = await _call(create_note, title="BlockedUntagTarget", notebook_name="Personal", body="x")
+        r = await _call(create_note, title="BlockedUntagTarget", notebook_name="E2ETest_Personal", body="x")
         nid = _extract_id(r)
         await _call(create_tag, title="e2e-al-untag-blocked")
         await _call(tag_note, note_id=nid, tag_name="e2e-al-untag-blocked")
 
-        with _allowlist_config(["AI"]):
+        with _allowlist_config(["E2ETest_AI"]):
             with pytest.raises(Exception):
                 await _call(untag_note, note_id=nid, tag_name="e2e-al-untag-blocked")
 
@@ -625,10 +631,10 @@ class TestTagsWithAllowlist:
         from joplin_mcp.tools.notes import create_note
         from joplin_mcp.tools.tags import get_tags_by_note
 
-        r = await _call(create_note, title="BlockedTagQuery", notebook_name="Personal", body="x")
+        r = await _call(create_note, title="BlockedTagQuery", notebook_name="E2ETest_Personal", body="x")
         nid = _extract_id(r)
 
-        with _allowlist_config(["AI"]):
+        with _allowlist_config(["E2ETest_AI"]):
             with pytest.raises(Exception):
                 await _call(get_tags_by_note, note_id=nid)
 
@@ -645,22 +651,22 @@ class TestMixedPatterns:
         from joplin_mcp.tools.notebooks import list_notebooks
         from joplin_mcp.tools.notes import create_note
 
-        with _allowlist_config(["AI", "Projects/*", "!Projects/Secret"]):
+        with _allowlist_config(["E2ETest_AI", "E2ETest_Projects/*", "!E2ETest_Projects/E2ETest_Secret"]):
             listing = await _call(list_notebooks)
-            assert "AI" in listing
-            assert "Work" in listing
-            assert "Secret" not in listing
-            assert "Personal" not in listing
+            assert "E2ETest_AI" in listing
+            assert "E2ETest_Work" in listing
+            assert "E2ETest_Secret" not in listing
+            assert "E2ETest_Personal" not in listing
 
             # Can create in allowed notebooks
-            r = await _call(create_note, title="MixedOK", notebook_name="AI", body="ok")
+            r = await _call(create_note, title="MixedOK", notebook_name="E2ETest_AI", body="ok")
             assert "MixedOK" in r
 
-            r2 = await _call(create_note, title="MixedOK2", notebook_name="Work", body="ok")
+            r2 = await _call(create_note, title="MixedOK2", notebook_name="E2ETest_Work", body="ok")
             assert "MixedOK2" in r2
 
             # Blocked notebooks
             with pytest.raises(Exception):
-                await _call(create_note, title="No", notebook_name="Secret", body="no")
+                await _call(create_note, title="No", notebook_name="E2ETest_Secret", body="no")
             with pytest.raises(Exception):
-                await _call(create_note, title="No", notebook_name="Personal", body="no")
+                await _call(create_note, title="No", notebook_name="E2ETest_Personal", body="no")

--- a/tests/e2e/test_e2e_tools.py
+++ b/tests/e2e/test_e2e_tools.py
@@ -189,51 +189,6 @@ async def test_e2e_tags_workflow(e2e_client):
 
 
 # ---------------------------------------------------------------------------
-# Allowlist enforcement
-# ---------------------------------------------------------------------------
-
-@pytest.mark.asyncio
-async def test_e2e_allowlist_enforcement(e2e_client):
-    """Create notebooks, configure allowlist, verify access control."""
-    from unittest.mock import patch
-
-    from joplin_mcp.config import JoplinMCPConfig
-    from joplin_mcp.tools.notebooks import create_notebook, list_notebooks
-    from joplin_mcp.tools.notes import create_note
-
-    await _call(create_notebook, title="E2E Allowed NB")
-    await _call(create_notebook, title="E2E Blocked NB")
-
-    restricted_config = JoplinMCPConfig(
-        token=e2e_client._token if hasattr(e2e_client, '_token') else "e2e_test_token",
-        notebook_allowlist=["E2E Allowed NB"],
-    )
-
-    with patch("joplin_mcp.tools.notes._module_config", restricted_config), \
-         patch("joplin_mcp.tools.notebooks._module_config", restricted_config):
-
-        result = await _call(
-            create_note,
-            title="Allowed Note",
-            notebook_name="E2E Allowed NB",
-            body="should work",
-        )
-        assert "Allowed Note" in result
-
-        with pytest.raises(Exception):
-            await _call(
-                create_note,
-                title="Blocked Note",
-                notebook_name="E2E Blocked NB",
-                body="should fail",
-            )
-
-        listing = await _call(list_notebooks)
-        assert "E2E Allowed NB" in listing
-        assert "E2E Blocked NB" not in listing
-
-
-# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
closes #29

## summary

five commits, one per issue bullet:

- **prefix fixture notebooks with `E2ETest_`** — fixes collisions with the developer's own notebooks (Projects / Personal / AI / Work / Secret / Diary). prefixes titles, dict keys, `_allowlist_config` pattern strings, and assertions, so the suite is deterministic against a populated joplin.
- **assert parent_id on positive write paths** — fetches via `e2e_client.get_note(nid)` (or `get_notebook`) and verifies `parent_id == hierarchy[X]` across create_note, update_note, edit_note, create_notebook, tag_note, untag_note. catches silent fallback-to-default-notebook regressions that the response-string check missed.
- **add coverage for 4 enforcing tools** — `get_links` (source-block + outgoing-target-filter + backlink-filter), `find_notes_with_tag` (filter + all-blocked), `find_in_note` (allow + block raises), `get_all_notes` (filter + all-blocked). introduces `_wait_for_search` to handle joplin's FTS lag — negative assertions would otherwise pass trivially on empty results and hide a broken filter.
- **drop duplicate `test_e2e_allowlist_enforcement`** from test_e2e_tools.py — covered by 48 dedicated tests in test_e2e_allowlist.py; test_e2e_tools.py now stays focused on tool plumbing (ping, CRUD, search, tags).
- **log warnings on e2e_cleanup failures** — replaces `try/except: pass` with `logger.warning(...)`, including the id, title, and underlying exception, so unrecoverable leftover state becomes observable. retry semantics unchanged.

## test plan

- [x] non-e2e suite: 607 passed (no regressions)
- [x] e2e allowlist suite (real joplin, 2 pre-existing broken tests deselected — see follow-ups): 46/46 passed

## follow-ups (discovered during this work)

- #30 — `tag_note` / `untag_note` allowlist tests expect raise but tools return reports
- #31 — `test_e2e_find_notes` assertion passes on empty results because the query string is echoed in the no-results template
