### PR TITLE
test: fix two false-positive e2e tests surfaced by #29

### DIFF
--- a/tests/e2e/test_e2e_allowlist.py
+++ b/tests/e2e/test_e2e_allowlist.py
@@ -621,8 +621,9 @@ class TestTagsWithAllowlist:
             assert "e2e-al-tag" in tags
 
     @pytest.mark.asyncio
-    async def test_tag_note_in_blocked_notebook_raises(self, hierarchy):
-        """Tagging a note in a blocked notebook should be denied."""
+    async def test_tag_note_in_blocked_notebook_reports_denial(self, hierarchy):
+        """Tagging a note in a blocked notebook is recorded as a failed op in
+        the bulk report (tag_note does not raise — see 96ace20)."""
         from joplin_mcp.tools.notes import create_note
         from joplin_mcp.tools.tags import create_tag, tag_note
 
@@ -631,8 +632,10 @@ class TestTagsWithAllowlist:
         await _call(create_tag, title="e2e-al-blocked-tag")
 
         with _allowlist_config(["E2ETest_AI"]):
-            with pytest.raises(Exception):
-                await _call(tag_note, note_id=nid, tag_name="e2e-al-blocked-tag")
+            result = await _call(tag_note, note_id=nid, tag_name="e2e-al-blocked-tag")
+            assert "STATUS: PARTIAL" in result
+            assert "FAILED: 1" in result
+            assert "not accessible" in result.lower()
 
     @pytest.mark.asyncio
     async def test_untag_note_in_allowed_notebook(self, hierarchy, e2e_client):
@@ -650,8 +653,9 @@ class TestTagsWithAllowlist:
             assert "success" in result.lower()
 
     @pytest.mark.asyncio
-    async def test_untag_note_in_blocked_notebook_raises(self, hierarchy):
-        """Untagging a note in a blocked notebook should be denied."""
+    async def test_untag_note_in_blocked_notebook_reports_denial(self, hierarchy):
+        """Untagging a note in a blocked notebook is recorded as a failed op
+        in the bulk report (untag_note does not raise — see 96ace20)."""
         from joplin_mcp.tools.notes import create_note
         from joplin_mcp.tools.tags import create_tag, tag_note, untag_note
 
@@ -661,8 +665,10 @@ class TestTagsWithAllowlist:
         await _call(tag_note, note_id=nid, tag_name="e2e-al-untag-blocked")
 
         with _allowlist_config(["E2ETest_AI"]):
-            with pytest.raises(Exception):
-                await _call(untag_note, note_id=nid, tag_name="e2e-al-untag-blocked")
+            result = await _call(untag_note, note_id=nid, tag_name="e2e-al-untag-blocked")
+            assert "STATUS: PARTIAL" in result
+            assert "FAILED: 1" in result
+            assert "not accessible" in result.lower()
 
     @pytest.mark.asyncio
     async def test_get_tags_by_note_in_blocked_notebook_raises(self, hierarchy):

--- a/tests/e2e/test_e2e_tools.py
+++ b/tests/e2e/test_e2e_tools.py
@@ -1,6 +1,8 @@
 """E2E tests exercising real MCP tool functions against a live Joplin instance."""
 
+import asyncio
 import re
+import time
 
 import pytest
 
@@ -11,6 +13,28 @@ async def _call(tool, **kwargs):
     """Call a FunctionTool or raw async function."""
     fn = getattr(tool, "fn", tool)
     return await fn(**kwargs)
+
+
+async def _wait_for_search(tool, *, expected: str, timeout: float = 15.0, **kwargs) -> str:
+    """Poll an FTS-backed search tool until ``expected`` appears in its output.
+
+    Joplin's FTS index lags note/tag mutations by several seconds, so tools
+    that go through ``client.search_all`` (find_notes, find_notes_with_tag)
+    can return empty immediately after a create. Without this wait, a
+    substring assertion like ``"Title" in result`` can pass on the
+    no-results template, which echoes the query back in its CONTEXT line.
+    """
+    deadline = time.monotonic() + timeout
+    last = ""
+    while time.monotonic() < deadline:
+        last = await _call(tool, **kwargs)
+        if expected in last:
+            return last
+        await asyncio.sleep(0.5)
+    raise AssertionError(
+        f"Timed out after {timeout}s waiting for {expected!r} in search output. "
+        f"Last output: {last!r}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -131,20 +155,26 @@ async def test_e2e_delete_note(e2e_client):
 
 @pytest.mark.asyncio
 async def test_e2e_find_notes(e2e_client):
-    """Create notes and search for them."""
+    """Create a note and search for it via find_notes."""
     from joplin_mcp.tools.notebooks import create_notebook
     from joplin_mcp.tools.notes import create_note, find_notes
 
     await _call(create_notebook, title="E2E Search NB")
-    await _call(
+    create_result = await _call(
         create_note,
         title="Unique Searchable Note Alpha",
         notebook_name="E2E Search NB",
         body="cantaloupe watermelon",
     )
+    note_id = _extract_id(create_result)
 
-    result = await _call(find_notes, query="Unique Searchable Note Alpha")
-    assert "Unique Searchable Note Alpha" in result
+    # Poll on the note id, not the title. Joplin's FTS index lags creation
+    # by several seconds, and the no-results template echoes the query
+    # back in its CONTEXT line — so a title substring would pass on an
+    # empty result. The note id only appears when a real row is returned.
+    await _wait_for_search(
+        find_notes, expected=note_id, query="Unique Searchable Note Alpha"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
closes #30, closes #31

two follow-ups discovered during #29, both about e2e tests that "passed" for the wrong reason.

## #30 — tag/untag allowlist tests expected raise

`tag_note` / `untag_note` were refactored in 96ace20 to return per-op reports (`TOTAL_OPS / SUCCEEDED / FAILED`) instead of raising on allowlist denial. the two `TestTagsWithAllowlist::*_raises` tests fired `pytest.raises(Exception)` that never matched. parse the report instead — assert `STATUS: PARTIAL`, `FAILED: 1`, and `"not accessible"` in the failure row — and rename the tests to `*_reports_denial`.

## #31 — find_notes test passed on empty results

`test_e2e_find_notes` asserted the note title appeared in the response. joplin's FTS lags creation by 5-10s, so the call usually hit the no-results template — which echoes the query back in its CONTEXT line — and the substring check was satisfied trivially.

extract the note id from `create_note`'s output and poll via a local `_wait_for_search` helper (parallel to the one in `test_e2e_allowlist.py`) until the id appears in a real result row. ids don't leak into the no-results template, so this can only pass on a true hit.

## test plan

- [x] non-e2e suite: 607 passed
- [x] full e2e suite against real joplin (with the unrelated pre-existing `test_e2e_delete_note` deselected — joplin soft-deletes to trash, so `get_note(deleted_id)` doesn't raise): 55/55 passed
