### PR TITLE
docs: add experimental headless deployment (docs + compose)

### DIFF
--- a/docker/docker-compose.headless.yml
+++ b/docker/docker-compose.headless.yml
@@ -1,0 +1,134 @@
+# docker/docker-compose.headless.yml
+#
+# EXPERIMENTAL — community-supported headless deployment.
+#
+# Runs Joplin fully server-side (no Joplin Desktop app required) so an MCP
+# client / AI agent can read & write notes on a VPS, NAS, or CI box, while
+# still syncing to your other devices (phone, laptop) through a normal
+# self-hosted Joplin Server.
+#
+# Architecture:
+#
+#   db (postgres) ── joplin-server ◄──sync──► your phone / laptop
+#                         ▲
+#                         │ sync target 9 (Joplin Server)
+#                    joplin-data-api   headless Joplin CLI + nginx token-injection proxy (:41185 → :41184)
+#                         ▲
+#                         │ Joplin Data API (token auto-injected by nginx)
+#                    joplin-mcp        FastMCP server (:8000)  ◄── AI agents
+#
+# Image versions are PINNED by digest (no :latest). The human-readable tag
+# the digest corresponds to is noted in a comment; both are kept in sync.
+# Tested-with versions: postgres 16.14, joplin/server 3.7.1,
+# joplin-terminal-data-api (digest below). See docs/headless.md for the full
+# guide, the one-time bootstrap, backup/restore, and caveats.
+#
+# Setup:
+#   cp env.headless.example .env   # then fill in the required secrets
+#   docker compose -f docker/docker-compose.headless.yml up -d
+#   # then run the one-time bootstrap in docs/headless.md to configure sync.
+#
+# AI clients connect to: http://localhost:${MCP_PORT:-8000}/mcp
+
+services:
+  db:
+    # PostgreSQL 16.14
+    image: postgres:16.14@sha256:081f1bc7bd5e143dbb6e487b710bbc27712cdcfaced4c071b8e47349aa1b4171
+    restart: unless-stopped
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER:-joplin}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}
+      - POSTGRES_DB=${POSTGRES_DB:-joplindb}
+    volumes:
+      - joplin_db:/var/lib/postgresql/data
+    networks:
+      - joplin_internal
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-joplin} -d ${POSTGRES_DB:-joplindb}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    # No published ports — postgres is private to the internal network.
+
+  joplin-server:
+    # Joplin Server 3.7.1
+    image: joplin/server:3.7.1@sha256:0877bfba41a943017c42c58e90db9d8d548bfe699b5e410248b5b879371734f9
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      - APP_PORT=22300
+      # Set this to the URL your OTHER devices use to reach the sync server.
+      - APP_BASE_URL=${JOPLIN_SERVER_BASE_URL:-http://localhost:8082}
+      - DB_CLIENT=pg
+      - POSTGRES_HOST=db
+      - POSTGRES_PORT=5432
+      - POSTGRES_DATABASE=${POSTGRES_DB:-joplindb}
+      - POSTGRES_USER=${POSTGRES_USER:-joplin}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}
+      - MAILER_ENABLED=0
+    ports:
+      # Exposed so your phone/laptop can sync to this server. Put it behind a
+      # reverse proxy with TLS in production. NOTE: this is the sync server,
+      # not the Data API — the Data API itself is never published (see below).
+      - "${JOPLIN_SERVER_PORT:-8082}:22300"
+    networks:
+      - joplin_internal
+
+  joplin-data-api:
+    # rickonono3/joplin-terminal-data-api — headless Joplin CLI + nginx proxy.
+    # Listens on :41185 and injects the Joplin Data API token into every request,
+    # proxying to the internal Joplin Data API on :41184. Pinned by digest
+    # (the image publishes :latest only).
+    # https://github.com/RickoNoNo3/joplin-terminal-data-api
+    image: rickonono3/joplin-terminal-data-api@sha256:f7d5a0152ac876e1feb56ed9b3d7a2331fd03b23a77cc9bbd37fe68c47e032aa
+    restart: unless-stopped
+    depends_on:
+      - joplin-server
+    environment:
+      - JOPLIN_PORT=41184
+    volumes:
+      # Persists the Joplin CLI profile (settings.json, database.sqlite, token).
+      # This is what you back up. The sync target is configured here once
+      # (see the bootstrap section in docs/headless.md).
+      - joplin_profile:/root/joplin
+      - ./joplin-data-api.nginx.conf.template:/etc/nginx/nginx.conf.template:ro
+    networks:
+      - joplin_internal
+    # NO published ports — the Data API is PRIVATE to the internal network.
+    # Only joplin-mcp (same network) may reach it. Never expose 41184/41185.
+
+  joplin-mcp:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    depends_on:
+      - joplin-data-api
+    environment:
+      # The real token is injected by the nginx proxy, so any non-empty value
+      # satisfies joplin-mcp's own config validation.
+      - JOPLIN_TOKEN=${JOPLIN_TOKEN:-injected-by-proxy}
+      # Reach the Data API by its compose service name over the internal network.
+      - JOPLIN_HOST=joplin-data-api
+      - JOPLIN_PORT=41185
+      - MCP_TRANSPORT=http
+      - MCP_HOST=0.0.0.0
+      - MCP_PORT=8000
+      - MCP_LOG_LEVEL=${MCP_LOG_LEVEL:-info}
+    ports:
+      - "${MCP_PORT:-8000}:8000"
+    networks:
+      - joplin_internal
+    # Uncomment to mount a config file for fine-grained tool control:
+    # volumes:
+    #   - ../joplin-mcp.json:/config/joplin-mcp.json:ro
+
+networks:
+  joplin_internal:
+    driver: bridge
+
+volumes:
+  joplin_db:
+  joplin_profile:

--- a/docker/joplin-data-api.nginx.conf.template
+++ b/docker/joplin-data-api.nginx.conf.template
@@ -1,0 +1,43 @@
+user                            www;
+worker_processes                auto;
+
+error_log                       /var/log/nginx/error.log warn;
+
+events {
+    worker_connections          1024;
+}
+
+http {
+    include                     /etc/nginx/mime.types;
+    default_type                application/octet-stream;
+    sendfile                    on;
+    access_log                  /var/log/nginx/access.log;
+    keepalive_timeout           3000;
+
+    # Strip any existing "token" query parameter so the proxy always
+    # injects the single, authoritative token. This lets upstream clients
+    # (e.g. joplin-mcp) send any placeholder token without getting a 403.
+    # The joplin-terminal-data-api image substitutes __TOKEN__ with the
+    # Joplin CLI's real Data API token at container start.
+    map $args $args_no_token {
+        "~^(.+)&token=[^&]*&(.+)$" "$1&$2";
+        "~^(.+)&token=[^&]*$"      $1;
+        "~^token=[^&]*&(.+)$"      $1;
+        "~^token=[^&]*$"            "";
+        default                     $args;
+    }
+
+    server {
+        listen               41185;
+        client_max_body_size 2048M;
+        location / {
+            set $args $args_no_token;
+            set $delimeter "";
+            if ($is_args) {
+              set $delimeter "&";
+            }
+            set $args "$args${delimeter}token=__TOKEN__";
+            proxy_pass http://localhost:41184;
+        }
+    }
+}

--- a/docs/headless.md
+++ b/docs/headless.md
@@ -1,0 +1,183 @@
+# Headless Deployment (Experimental)
+
+> **Status: experimental, community-supported.**
+> This is **not** the recommended Docker setup. It runs a headless Joplin client
+> stack so an MCP server / AI agent can operate on your notes without the Joplin
+> Desktop app. It carries operational risk that a normal desktop client does not
+> (upgrade and sync behaviour against a long-lived headless profile). Read the
+> [Safety & failure modes](#safety--failure-modes) section before you rely on it,
+> and **back up before every upgrade**.
+
+## Why this exists
+
+The standard Docker setup needs `JOPLIN_TOKEN`, which you can only get from the
+Web Clipper settings of a **running Joplin Desktop instance**. That makes a fully
+server-side deployment (VPS, NAS, CI) impossible.
+
+This setup removes the Desktop dependency by running Joplin headlessly via
+[`joplin-terminal-data-api`](https://github.com/RickoNoNo3/joplin-terminal-data-api)
+(a headless Joplin CLI plus a small nginx proxy that auto-injects the Data API
+token). You get a **headless participant** in your normal Joplin sync — your
+phone and laptop keep syncing as usual; the server is just another client with no
+GUI.
+
+## Architecture
+
+```
+db (postgres) ── joplin-server ◄──sync──► your phone / laptop
+                      ▲
+                      │ sync target 9 (Joplin Server)
+                 joplin-data-api   headless Joplin CLI + nginx token proxy (:41185 → :41184)
+                      ▲
+                      │ Joplin Data API (token auto-injected)
+                 joplin-mcp        FastMCP server (:8000)  ◄── AI agents
+```
+
+| Service | Role | Published port |
+| --- | --- | --- |
+| `db` | PostgreSQL store for Joplin Server | none (private) |
+| `joplin-server` | Joplin sync server | `8082` (for your other devices) |
+| `joplin-data-api` | Headless Joplin CLI + token-injecting proxy | **none (private)** |
+| `joplin-mcp` | This MCP server | `8000` |
+
+## Pinned image versions
+
+The compose file pins every image **by digest** (no `:latest`) so a redeploy is
+reproducible and an upstream image change can never silently alter behaviour.
+
+| Image | Tag | Tested with |
+| --- | --- | --- |
+| `postgres` | `16.14` | PostgreSQL 16.14 |
+| `joplin/server` | `3.7.1` | Joplin Server 3.7.1 |
+| `rickonono3/joplin-terminal-data-api` | digest-pinned | publishes `:latest` only; pinned by digest |
+| `joplin-mcp` | built from this repo's `Dockerfile` | — |
+
+To bump a version: change one digest, run the smoke tests below, then commit.
+Rollback is reverting to the previous digest.
+
+## Networking: keep the Data API private
+
+The Joplin Data API has **no authentication of its own** in this setup — the
+nginx proxy injects the token, so anything that can reach `:41185` has full
+read/write access to your notes. Therefore:
+
+- `joplin-data-api` and `db` publish **no host ports**; they live only on the
+  internal `joplin_internal` network.
+- Only `joplin-mcp` (on the same network) talks to the Data API.
+- `joplin-server` is published on `8082` because your other devices must reach
+  it to sync — put it behind a reverse proxy with TLS in production.
+
+### Port choice: `41185` (auto-token proxy) vs `41184` (explicit token)
+
+This setup uses **`41185`**, the nginx proxy port. The proxy strips any token a
+client sends and injects the Joplin CLI's real token, so `joplin-mcp` can send a
+placeholder. The token is managed entirely inside the container — you never copy
+it into your environment.
+
+The alternative is to connect directly to **`41184`** (the raw Joplin Data API)
+and pass a real `JOPLIN_TOKEN`. That works too, but you must extract the token
+from the profile and keep it in your `.env`. The proxy approach (`41185`) is
+preferred for headless because there is no token to manage or leak.
+
+## Volume layout & backup/restore
+
+Two named volumes hold all state:
+
+| Volume | Contents | Back this up |
+| --- | --- | --- |
+| `joplin_db` | PostgreSQL data (all notes, as synced by Joplin Server) | **yes** |
+| `joplin_profile` | Joplin CLI profile: `settings.json`, `database.sqlite`, Data API token | **yes** |
+
+**Back up before every upgrade.** Example (stop the stack first for a consistent snapshot):
+
+```bash
+docker compose -f docker/docker-compose.headless.yml stop
+docker run --rm -v joplin_db:/data -v "$PWD":/backup alpine \
+  tar czf /backup/joplin_db.tgz -C /data .
+docker run --rm -v joplin_profile:/data -v "$PWD":/backup alpine \
+  tar czf /backup/joplin_profile.tgz -C /data .
+docker compose -f docker/docker-compose.headless.yml start
+```
+
+Restore is the reverse: recreate the volume and untar into it before starting.
+
+## First-run bootstrap (one time)
+
+Image env vars are **not** enough to configure sync — the sync target is stored
+in the Joplin CLI profile, which you set once. After `docker compose ... up -d`:
+
+1. **Create a sync user on Joplin Server.** Open `http://localhost:8082`, log in
+   with the default admin (`admin@localhost` / `admin`), change the password, and
+   (recommended) create a dedicated user for the headless client.
+
+2. **Configure sync inside the Data API container** and do the first sync:
+
+   ```bash
+   docker compose -f docker/docker-compose.headless.yml exec joplin-data-api sh -lc '
+     joplin config sync.target 9
+     joplin config sync.9.path http://joplin-server:22300
+     joplin config sync.9.username "you@example.com"
+     joplin config sync.9.password "your-password"
+     joplin sync
+   '
+   ```
+
+   `sync.target 9` is **Joplin Server**. Other targets: `7` WebDAV, `5` Nextcloud,
+   `8` Amazon S3, `2` local filesystem, `10` Joplin Cloud — adjust the `sync.*`
+   keys accordingly.
+
+3. **Verify** the MCP server can reach the notes:
+
+   ```bash
+   curl -s http://localhost:8000/mcp -H 'Accept: text/event-stream' | head
+   ```
+
+The token is generated and injected automatically; you do not configure it.
+
+## End-to-end encryption (E2EE)
+
+This setup is documented and tested with **E2EE disabled**. The headless Joplin
+CLI must read and write note content in plaintext to serve the Data API, so:
+
+- If your sync account has **E2EE enabled**, you must also set the master password
+  in the CLI profile (`joplin e2ee decrypt` / configure the master key) for the
+  headless client to read notes — otherwise it syncs only ciphertext and the MCP
+  tools see nothing useful.
+- Treat the `joplin_profile` volume as **highly sensitive** either way: it holds
+  the Data API token and, if E2EE is enabled, the master key material.
+- Recommendation: run the headless client on a trusted, access-controlled host and
+  keep the Data API private (as configured).
+
+## Safety & failure modes
+
+The main concern with a headless client is an upgrade or sync error corrupting the
+store. Mitigations built into this setup and workflow:
+
+- **`sync.wipeOutFailSafe` (on by default):** Joplin refuses to propagate a delete
+  of all notes when the remote suddenly looks empty — guards against a bad sync
+  wiping your data. Leave it enabled.
+- **Pinned digests:** an upstream image can't change under you; upgrades are
+  deliberate and reversible by digest.
+- **Backup before upgrade:** see above — the single most important habit.
+- **Upgrade workflow:** back up → bump one image digest → `up -d` → run the smoke
+  tests → confirm a successful `joplin sync` → only then continue. If anything
+  looks wrong, restore the volumes and revert the digest.
+- **Known caveats:** the headless CLI version and your other clients' versions can
+  drift; after upgrading the Data API image, run a manual `joplin sync` and watch
+  the logs (`docker compose ... logs joplin-data-api`) before trusting it.
+
+## Smoke tests
+
+```bash
+# Static validation (no containers started)
+docker compose -f docker/docker-compose.headless.yml config
+
+# After bootstrap: confirm the MCP endpoint responds
+curl -s http://localhost:8000/mcp -H 'Accept: text/event-stream' | head
+
+# Confirm headless sync works
+docker compose -f docker/docker-compose.headless.yml exec joplin-data-api \
+  sh -lc 'joplin sync && joplin ls'
+```
+
+See also [`docs/agent-smoke-tests.md`](agent-smoke-tests.md) for MCP-level checks.

--- a/env.headless.example
+++ b/env.headless.example
@@ -1,0 +1,25 @@
+# Environment template for the EXPERIMENTAL headless deployment.
+# Copy to .env and fill in the secrets, then:
+#   docker compose -f docker/docker-compose.headless.yml up -d
+#
+# Do NOT commit your real .env.
+
+# --- PostgreSQL (Joplin Server's database) ---
+POSTGRES_USER=joplin
+POSTGRES_PASSWORD=change-me-to-a-strong-password
+POSTGRES_DB=joplindb
+
+# --- Joplin Server ---
+# Host port to expose the sync server on (for your phone/laptop to sync to).
+JOPLIN_SERVER_PORT=8082
+# The URL your other devices use to reach this sync server.
+# Use your real domain (behind TLS) in production.
+JOPLIN_SERVER_BASE_URL=http://localhost:8082
+
+# --- joplin-mcp ---
+# Host port for the MCP endpoint (AI clients connect to http://localhost:8000/mcp).
+MCP_PORT=8000
+MCP_LOG_LEVEL=info
+# The real Data API token is injected by the nginx proxy; any non-empty
+# placeholder satisfies joplin-mcp's config validation.
+JOPLIN_TOKEN=injected-by-proxy


### PR DESCRIPTION
Implements the headless deployment path discussed in #14, scoped exactly to what was requested there: experimental, community-supported.

### Adds
- `docs/headless.md` — setup, one-time sync bootstrap, port/token choices, volume layout, backup/restore, E2EE caveats, and upgrade & failure modes.
- `docker/docker-compose.headless.yml` — full self-contained stack (postgres + joplin-server + joplin-data-api + joplin-mcp).
- `docker/joplin-data-api.nginx.conf.template` — the token-injection proxy config.
- `env.headless.example` — environment template.

### Checklist from #14
- **Pinned image versions by digest** (no `:latest`), with a "tested with" table.
- **Data API kept private** — internal network, no published ports; only the MCP server is exposed.
- Documents **`41185` auto-token proxy** (default) vs **`41184` explicit token**.
- **Named volumes + backup/restore** guidance.
- **Sync target configuration** (Joplin Server / target 9) via a documented one-time bootstrap.
- **E2EE status and caveats** (documented with E2EE disabled; caveat noted for E2EE-enabled accounts).
- **Upgrade / failure modes** + a back-up → bump digest → smoke-test → verify-sync workflow; `sync.wipeOutFailSafe` documented as a guard.

The framing is explicitly **experimental / community-supported** throughout, not presented as the recommended setup. Tested against a deployment running this stack (postgres 16.14, joplin/server 3.7.1).

Closes #14.