### PR TITLE
Fix import tool schema for strict-client compatibility (Copilot)

### DIFF
--- a/src/joplin_mcp/imports/tools.py
+++ b/src/joplin_mcp/imports/tools.py
@@ -26,10 +26,24 @@ from .types import ImportOptions
 logger = logging.getLogger(__name__)
 
 
+def _require_all_properties(schema: Dict[str, Any], _model: Any) -> None:
+    """Make object schemas strict-client compatible.
+
+    Some strict function-schema validators require every declared property to
+    appear in ``required`` even when the field itself is nullable.
+    """
+    properties = schema.get("properties")
+    if isinstance(properties, dict):
+        schema["required"] = list(properties.keys())
+
+
 class ImportFromFileOptions(BaseModel):
     """Structured import options exposed through the MCP schema."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(
+        extra="forbid",
+        json_schema_extra=_require_all_properties,
+    )
 
     handle_duplicates: Optional[Literal["skip", "overwrite", "rename"]] = None
     create_missing_notebooks: Optional[bool] = None

--- a/src/joplin_mcp/imports/tools.py
+++ b/src/joplin_mcp/imports/tools.py
@@ -3,9 +3,9 @@ import ast
 import json
 import logging
 from pathlib import Path
-from typing import Annotated, Any, Dict, Optional, Union
+from typing import Annotated, Any, Dict, Literal, Optional
 
-from pydantic import Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from joplin_mcp.config import JoplinMCPConfig
 from joplin_mcp.fastmcp_server import create_tool, get_joplin_client
@@ -24,6 +24,29 @@ from .importers.utils import looks_like_raw_export
 from .types import ImportOptions
 
 logger = logging.getLogger(__name__)
+
+
+class ImportFromFileOptions(BaseModel):
+    """Structured import options exposed through the MCP schema."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    handle_duplicates: Optional[Literal["skip", "overwrite", "rename"]] = None
+    create_missing_notebooks: Optional[bool] = None
+    create_missing_tags: Optional[bool] = None
+    preserve_timestamps: Optional[bool] = None
+    max_batch_size: Optional[int] = Field(default=None, ge=1)
+    attachment_handling: Optional[Literal["link", "embed", "skip"]] = None
+    encoding: Optional[str] = None
+    max_file_size_mb: Optional[int] = Field(default=None, ge=1)
+    file_pattern: Optional[str] = None
+    preserve_structure: Optional[bool] = None
+    preserve_directory_structure: Optional[bool] = None
+    csv_import_mode: Optional[Literal["table", "rows"]] = None
+    csv_delimiter: Optional[str] = Field(
+        default=None, min_length=1, max_length=1, description="Single-character CSV delimiter override"
+    )
+    extract_hashtags: Optional[bool] = None
 
 
 # === UTILITY FUNCTIONS ===
@@ -294,8 +317,8 @@ async def import_from_file(
         Optional[str], Field(description="Target notebook name (optional, defaults to 'Imported')")
     ] = 'Imported',
     import_options: Annotated[
-        Optional[Union[Dict[str, Any], str]],
-        Field(description="Additional import options (object/dict; string is auto-parsed)")
+        Optional[ImportFromFileOptions],
+        Field(description="Additional structured import options")
     ] = None,
 ) -> str:
     """Import notes from a file or directory.
@@ -378,7 +401,9 @@ async def import_from_file(
             max_file_size_mb=config.import_settings.get("max_file_size_mb", 100),
         )
 
-        # Apply additional options (accept dict or JSON/Python-dict string)
+        # Apply additional options. Older direct Python callers may still pass a
+        # JSON/Python-dict string even though the MCP schema now exposes this as
+        # an object-only parameter for better client compatibility.
         if import_options:
             if isinstance(import_options, str):
                 try:
@@ -392,6 +417,10 @@ async def import_from_file(
                         return "VALIDATION_ERROR: import_options string did not parse to an object"
                 except Exception:
                     return "VALIDATION_ERROR: import_options must be an object or JSON/dict string"
+            elif isinstance(import_options, BaseModel):
+                import_options = import_options.model_dump(exclude_none=True)
+            elif not isinstance(import_options, dict):
+                return "VALIDATION_ERROR: import_options must be an object or JSON/dict string"
             # Merge structured options
             for key, value in import_options.items():
                 if hasattr(base_options, key):

--- a/tests/test_fastmcp_server.py
+++ b/tests/test_fastmcp_server.py
@@ -224,6 +224,35 @@ async def test_update_note_has_todo_due_param():
             pytest.fail("update_note tool not found")
 
 
+@pytest.mark.asyncio
+async def test_import_from_file_schema_uses_object_for_import_options():
+    """Test that import_from_file exposes import_options as an object-only schema.
+
+    Some MCP clients reject union schemas here, especially Dict|str|None, so the
+    wire schema should stay object-shaped while the Python implementation can
+    still keep legacy string parsing for direct callers.
+    """
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+        for tool in tools:
+            if tool.name == "import_from_file":
+                schema = tool.inputSchema
+                assert schema and "properties" in schema
+                properties = schema["properties"]
+                assert "import_options" in properties
+                import_options = properties["import_options"]
+                assert "anyOf" in import_options
+                option_types = {option["type"] for option in import_options["anyOf"]}
+                assert option_types == {"object", "null"}
+                object_branch = next(
+                    option for option in import_options["anyOf"] if option["type"] == "object"
+                )
+                assert object_branch["additionalProperties"] is False
+                break
+        else:
+            pytest.fail("import_from_file tool not found")
+
+
 # === Tests for path-based notebook resolution ===
 
 

--- a/tests/test_fastmcp_server.py
+++ b/tests/test_fastmcp_server.py
@@ -248,6 +248,7 @@ async def test_import_from_file_schema_uses_object_for_import_options():
                     option for option in import_options["anyOf"] if option["type"] == "object"
                 )
                 assert object_branch["additionalProperties"] is False
+                assert set(object_branch["required"]) == set(object_branch["properties"].keys())
                 break
         else:
             pytest.fail("import_from_file tool not found")


### PR DESCRIPTION
This pull request refactors the `import_from_file` tool's import options to use a structured Pydantic model instead of a loosely-typed union, improving schema compatibility and client interoperability. It introduces a new `ImportFromFileOptions` model, ensures all properties are required in the schema for strict validation, and updates both implementation and tests to support and verify these changes.

--

This is motivated after a change in behaviour of Copilot HTTP adapter that made the MCP unusable for that provider. The issue was only with import from file tool.